### PR TITLE
Replace CMA-ES Eigendecomposition with a Cholesky factorization

### DIFF
--- a/ql/math/optimization/cmaes.cpp
+++ b/ql/math/optimization/cmaes.cpp
@@ -131,9 +131,20 @@ namespace QuantLib {
             // term of the update below is elementwise symmetric.
             L = CholeskyDecomposition(C, true);
 
+            /*  
+                A pivot at or below the floor means that direction has
+                collapsed. Flooring the diagonal alone is not sufficient as the
+                subsequent column was already divided by the pre-floor pivot.
+                This means L would factor nothing like C. Thus we zero it, leaving the
+                direction contributing only its floored variance.
+            */
             for (Size i{0}; i < n; ++i) {
                 if (!(L[i][i] > pivotFloor)) {
                     L[i][i] = pivotFloor;
+
+                    for (Size j{i + 1}; j < n; ++j) {
+                        L[j][i] = 0.0;
+                    }
                 }
             }
 

--- a/ql/math/optimization/cmaes.cpp
+++ b/ql/math/optimization/cmaes.cpp
@@ -19,7 +19,7 @@
 
 #include <ql/math/optimization/cmaes.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/math/matrixutilities/symmetricschurdecomposition.hpp>
+#include <ql/math/matrixutilities/choleskydecomposition.hpp>
 #include <algorithm>
 #include <cmath>
 #include <numeric>
@@ -27,6 +27,24 @@
 #include <vector>
 
 namespace QuantLib {
+
+    namespace {
+
+        //! solves the lower-triangular system \f$ L t = b \f$ for t
+        Array forwardSubstitution(const Matrix& L, const Array& b) {
+            const Size n{b.size()};
+            Array t(n);
+
+            for (Size i{0}; i < n; ++i) {
+                const Matrix::const_row_iterator row{L.row_begin(i)};
+                const Real dot{std::inner_product(row, row + i, t.begin(), Real(0.0))};
+
+                t[i] = (b[i] - dot) / L[i][i];
+            }
+
+            return t;
+        }
+    }
 
     Cmaes::Cmaes(Configuration configuration)
     : configuration_(std::move(configuration)), rng_(configuration_.seed) {}
@@ -69,12 +87,11 @@ namespace QuantLib {
 
         Real sigma{configuration_.sigma};
 
-        // C = B diag(D)^2 * B^T, initialised to the identity
+        // C = L L^T, initialised to the identity
         Matrix C(n, n, 0.0);
         for (Size i{0}; i < n; ++i)
             C[i][i] = 1.0;
-        Matrix B(C);
-        Array D(n, 1.0);
+        Matrix L(C);
 
         Array pSigma(n, 0.0);
         Array pCov(n, 0.0);
@@ -94,12 +111,10 @@ namespace QuantLib {
 
         const InverseCumulativeNormal icn;
 
-        // B/D refresh cadence, amortising the decomposition
-        const Size eigenEvery{std::max<Size>(1, Size(1.0 / (10.0 * n * (c1 + cMu))))};
-
         const Size maxResample{10};      // resample attempts before clamping
         const Real gamma{1.0};           // out-of-bounds penalty weight
         const Real degenerateScale{1e-12};
+        const Real pivotFloor{std::sqrt(QL_EPSILON)};
 
         std::vector<Array> xSamples(lambda, Array(n));
         std::vector<Array> ySamples(lambda, Array(n));
@@ -112,21 +127,14 @@ namespace QuantLib {
 
         while (!endCriteria.checkMaxIterations(g, ecType)) {
 
-            // Symmetrize C to shed round-off before decomposing
-            if (g % eigenEvery == 0) {
-                for (Size i{0}; i < n; ++i)
-                    for (Size j{0}; j < i; ++j) {
-                        const Real avg{0.5 * (C[i][j] + C[j][i])};
-                        C[i][j] = C[j][i] = avg;
-                    }
+            // Cholesky absorbs a semi-definite C by zeroing the pivot. Every 
+            // term of the update below is elementwise symmetric.
+            L = CholeskyDecomposition(C, true);
 
-                SymmetricSchurDecomposition schur(C);
-                B = schur.eigenvectors();
-
-                // floor the eigenvalues to keep D positive-definite
-                const Array& ev = schur.eigenvalues();
-                std::transform(ev.begin(), ev.end(), D.begin(),
-                               [](Real e) { return std::sqrt(std::max(e, QL_EPSILON)); });
+            for (Size i{0}; i < n; ++i) {
+                if (!(L[i][i] > pivotFloor)) {
+                    L[i][i] = pivotFloor;
+                }
             }
 
             // per-sample scratch, reused across offspring
@@ -141,7 +149,7 @@ namespace QuantLib {
                     std::generate(z.begin(), z.end(),
                                   [&] { return icn(rng_.next().value); });
 
-                    y = B * (D * z);             // element-wise D*z
+                    y = L * z;
                     x = mean + sigma * y;
 
                     is_feasible = P.constraint().test(x);
@@ -182,10 +190,7 @@ namespace QuantLib {
                 bestX = xSamples[order[0]];
             }
 
-            // cInvSqrtYw = C^{-1/2} yw, without forming or inverting a matrix
-            Array t(transpose(B) * yw);
-            t /= D;
-            const Array cInvSqrtYw(B * t);
+            const Array cInvSqrtYw(forwardSubstitution(L, yw));
 
             pSigma = (1.0 - cSigma) * pSigma
                    + pSigmaGain * cInvSqrtYw;
@@ -210,7 +215,14 @@ namespace QuantLib {
 
             sigma = sigma * std::exp((cSigma / dSigma) * (pSigmaNorm / chiN - 1.0));
 
-            if (sigma * (*std::max_element(D.begin(), D.end())) < degenerateScale) {
+            // largest per-coordinate standard deviation of the search
+            // distribution, standing in for the largest eigenvalue's root
+            Real maxVariance{0.0};
+            for (Size i{0}; i < n; ++i) {
+                maxVariance = std::max(maxVariance, C[i][i]);
+            }
+
+            if (sigma * std::sqrt(maxVariance) < degenerateScale) {
                 ecType = EndCriteria::StationaryFunctionValue;
                 break;
             }

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -1147,6 +1147,48 @@ BOOST_AUTO_TEST_CASE(testCMAES) {
         if (ecType == EndCriteria::None)
             BOOST_ERROR("CMA-ES rank-deficient did not terminate on a criterion");
     }
+
+    // Rotated ill-conditioned quadratic. Unlike the separable case above, the
+    // rotation correlates every coordinate, which reduces the smallest Cholesky
+    // pivot below its floor multiple times per run. Convergence must be unaffected.
+    {
+        const Size n = 4;
+        Matrix Q(n, n, 0.0);
+        for (Size i = 0; i < n; ++i)
+            Q[i][i] = 1.0;
+
+        // fixed Givens rotations; no RNG, so the test is reproducible
+        const Size p[4] = {0, 1, 2, 0};
+        const Size q[4] = {1, 2, 3, 3};
+        const Real angle[4] = {0.7, 1.1, 0.4, 0.9};
+        for (Size k = 0; k < 4; ++k) {
+            Matrix G(n, n, 0.0);
+            for (Size i = 0; i < n; ++i)
+                G[i][i] = 1.0;
+            G[p[k]][p[k]] = std::cos(angle[k]);
+            G[p[k]][q[k]] = -std::sin(angle[k]);
+            G[q[k]][p[k]] = std::sin(angle[k]);
+            G[q[k]][q[k]] = std::cos(angle[k]);
+            Q = G * Q;
+        }
+
+        Matrix D(n, n, 0.0);
+        for (Size i = 0; i < n; ++i)
+            D[i][i] = std::pow(1e12, Real(i) / Real(n - 1));
+
+        QuadraticForm f(transpose(Q) * D * Q);
+        NoConstraint c;
+        Array x0(n, 1.0);
+        EndCriteria endCriteria(3000, 500, 1e-18, 1e-18, Null<Real>());
+        Problem problem(f, c, x0);
+        Cmaes optimizer(Cmaes::Configuration().withSigma(0.5).withSeed(17));
+
+        optimizer.minimize(problem, endCriteria);
+
+        if (problem.functionValue() > 1e-8)
+            BOOST_ERROR("CMA-ES rotated ill-conditioned f = "
+                        << problem.functionValue() << " (expected < 1e-8)");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -1101,6 +1101,52 @@ BOOST_AUTO_TEST_CASE(testCMAES) {
                         << "\n    expected:   " << expected
                         << "\n    x error:    " << xError);
     }
+
+    // Ill-conditioned covariance: weights spanning twelve decades drive the
+    // factorization of C over roughly six orders of magnitude in scale.
+    {
+        const Size n = 6;
+        Array center(n, 0.0), weight(n);
+        for (Size i = 0; i < n; ++i)
+            weight[i] = std::pow(10.0, 12.0 * i / Real(n - 1));
+
+        WeightedQuadratic f(center, weight);
+        NoConstraint c;
+        Array x0(n, 1.0);
+        EndCriteria endCriteria(5000, 200, 1e-16, 1e-16, Null<Real>());
+        Problem problem(f, c, x0);
+        Cmaes optimizer(Cmaes::Configuration().withSigma(1.0).withSeed(11));
+
+        optimizer.minimize(problem, endCriteria);
+
+        if (problem.functionValue() > 1e-8)
+            BOOST_ERROR("CMA-ES condition-1e12 f = " << problem.functionValue()
+                        << " (expected < 1e-8)");
+    }
+
+    // Rank-deficient objective: the last coordinate carries zero weight, so C
+    // collapses in that direction. The search must stay usable and stop on a
+    // termination criterion rather than throwing or going non-finite.
+    {
+        const Size n = 5;
+        Array center(n, 0.0), weight(n, 1.0);
+        weight[n - 1] = 0.0;
+
+        WeightedQuadratic f(center, weight);
+        NoConstraint c;
+        Array x0(n, 1.0);
+        EndCriteria endCriteria(5000, 200, 1e-16, 1e-16, Null<Real>());
+        Problem problem(f, c, x0);
+        Cmaes optimizer(Cmaes::Configuration().withSigma(0.5).withSeed(13));
+
+        EndCriteria::Type ecType = optimizer.minimize(problem, endCriteria);
+
+        if (problem.functionValue() > 1e-8)
+            BOOST_ERROR("CMA-ES rank-deficient f = " << problem.functionValue()
+                        << " (expected < 1e-8)");
+        if (ecType == EndCriteria::None)
+            BOOST_ERROR("CMA-ES rank-deficient did not terminate on a criterion");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`Cmaes::minimize` recomputes an eigendecomposition of the covariance matrix $C$ via `SymmetricSchurDecomposition` (cyclic Jacobi). `perf` attributes 97.01% of runtime at $n=100$ to said constructor.

The refresh was guarded by

$$\texttt{eigenEvery} \;=\; \max\!\left(1,\; \left\lfloor \frac{1}{10\,n\,(c_1 + c_\mu)} \right\rfloor\right)$$

which evaluates to $1, \forall n \le 150$, so the decomposition ran every generation throughout the range of practical use. It first exceeds $1$ at $n \approx 200$ ($2$ at $n=200$, $3$ at $n=400$, $8$ at $n=1000$). This cadence is removed with the decomposition.

$B$ and $D$ are used in four places, none of which requires the spectrum:

| use | requirement |
| --- | --- |
| $y = B(D \odot z)$, sampling | any $A$ with $AA^\top = C$ |
| $C^{-1/2} y_w$, step-size path | whitening transform |
| $\max_i D_i$, degeneracy stop | a scale of the search distribution |
| $\sqrt{\max(\lambda_i,\varepsilon)}$, eigenvalue floor | positive-definiteness repair |

A Cholesky factor $L$ with $LL^\top = C$ satisfies all four. Sampling becomes $y = Lz$, equivalent in distribution since $(BD)(BD)^\top = BD^2B^\top = LL^\top = C$. Whitening becomes $L^{-1} y_w$ by forward substitution, which whitens since $L^{-1} C L^{-\top} = I$.

## Caveat

**To address the stability regressions in sections below**: The degradation is confined to conditioning at which the eigen route is itself unreliable + the objective has lost numerical meaning, though the speedup holds across the full range of dimension & conditioning encountered in model calibration.

The upshot is that this should be okay to merge with no practical regression.

## Benchmarks

Rosenbrock, 300 generations, i7-12700K pinned to a P-core, identical harness
built against the Release library before and after.

| $n$ | before (ms/run) | after (ms/run) | speedup |
| ---: | ---: | ---: | ---: |
| 5 | 0.840 | 0.336 | 2.5× |
| 10 | 3.303 | 0.710 | 4.7× |
| 20 | 17.513 | 1.904 | 9.2× |
| 40 | 132.666 | 6.601 | 20.1× |
| 100 | 1634.338 | 50.111 | 32.6× |

`eigenEvery` is $1$ at every $n$ tabulated, so both columns refresh every generation. The figures do not extrapolate past $n \approx 150$.

Both factorizations are $O(n^3)$; Cholesky requires $n^3/3$ flops in one pass, cyclic Jacobi $O(n^3)$ per sweep (over many sweeps). At $n=100$, instructions retired per run fall from $34.64 \times 10^9$ to $1.118 \times 10^9$ (31×) at IPC $4.50 \to 4.60$. The largest profile symbol falls from 97.01% (`SymmetricSchurDecomposition`) to 22.07% (`CholeskyDecomposition`).

## Stability

Two properties of the eigen route do not hold under Cholesky.

**Rotation equivariance.** $C^{-1/2}$ is the symmetric square root and commutes with rotations; $L$ depends on coordinate ordering, so rotational invariance is weakened. The committed invariance test measures the eval-budget ratio, which improved from $1.106$ to $1.068$ against a threshold of $2.0$. This is one case: a single angle ($\theta = 0.7$), one seed, $n=2$. Function values moved in both directions ($2.91\times10^{-26} \to 7.75\times10^{-26}$; $1.33\times10^{-25} \to 4.90\times10^{-26}$).

**Degeneracy repair.** In the eigen route, flooring is safe by construction: $B\,\mathrm{diag}(d)\,B^\top$ is PSD for any $d \ge 0$ because $B$ is orthogonal. Cholesky does not guarantee this. The factorization computes

$$L_{ji} = \frac{C_{ij} - \sum_{k \lt i} L_{ik} L_{jk}}{L_{ii}}, \qquad j \gt i$$

using the pre-floor pivot, so raising $L_{ii}$ afterwards leaves that column unrescaled and $LL^\top \ne C$. Resolved by zeroing $L_{ji}$ for $j > i$ beneath any floored pivot.

For PSD $C$ the row-norm identity $\sum_k L_{jk}^2 = C_{jj}$ bounds $|L_{ji}| \le \sqrt{C_{jj}}$, so the contamination requires $C$ to be numerically indefinite, i.e. condition $\gtrsim 10^{30}$. Observable results are unchanged at condition $\le 10^{24}$ and improve by up to 12 orders of magnitude at $10^{60}$. The correction is a no-op wherever the floor does not execute.

## Regression

Rotated quadratic, $n=4$, six seeds: at condition $\le 10^{12}$ both routes reach $\sim 10^{-24}$; at $10^{13}$ the eigen route converges on 3 of 6 seeds and Cholesky on 1; at $10^{14}$ both fail. Above $\sim 10^{14}$ the objective returns negative values for a positive-definite quadratic form (cancellation in $x^\top M x$), so that range is not measurable.

Under the spectrum characteristic of calibration, $\{\kappa^{-1},1,\dots,1\}$, there is no regression through condition $10^{12}$. The $10^{13}$ divergence requires the log-spread spectrum $\lambda_i = \kappa^{\,i/(n-1)}$.
