### PR TITLE
crash fixed due to throw an unhandled exception (QuantLib::Error) 

### DIFF
--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -163,6 +163,12 @@ namespace QuantLib {
         Real forwardPrice = spot * dividendDiscount / riskFreeDiscount;
         BlackCalculator black(payoff, forwardPrice, std::sqrt(variance),
                               riskFreeDiscount);
+        // SAFETY FIX: Prevent division by zero and nan/inf crashes when volatility is tiny.
+        if (variance < 1.0e-8) {
+            Real intrinsicValue = (*payoff)(spot);
+            results_.value = std::max(black.value(), intrinsicValue);
+            return;
+        }
 
         if (dividendDiscount>=1.0 && payoff->optionType()==Option::Call) {
             // early exercise never optimal


### PR DESCRIPTION
Here is a clean PR description template you can paste into GitHub:DescriptionFixes an uncaught QuantLib::Error exception in BaroneAdesiWhaleyApproximationEngine when pricing American options with near-zero or low volatility inputs.When variance drops near zero, the internal critical price computation ($S_u$) collapses onto the strike price ($K$). This leads to a division-by-zero scenario evaluating h, yielding inf/nan values downstream in blackFormula and throwing an exception (forward + displacement (nan + 0) must be positive).