### PR TITLE
Fuse predictor and corrector reduction loops in `FractionalAdams::solve`

### DIFF
--- a/ql/math/ode/fractionaladams.hpp
+++ b/ql/math/ode/fractionaladams.hpp
@@ -94,17 +94,19 @@ namespace QuantLib {
             for (Size n{0}; n < steps; ++n) {
                 const Real tNext{(n + 1) * dt};
 
-                T predictorSum{predictorWeights[n] * f[0]};
-                for (Size j{1}; j <= n; ++j)
-                    predictorSum += predictorWeights[n - j] * f[j];
-                const T yP{y0 + dtAlpha / gamma1 * predictorSum};
-
                 // corrector weight of f_0: n ^ (alpha + 1) - (n - alpha)(n + 1) ^ alpha
                 const Real a0{alphaPlusOnePowers[n] - (n - alpha_) * alphaPowers[n + 1]};
 
+                T predictorSum{predictorWeights[n] * f[0]};
                 T correctorSum{a0 * f[0]};
-                for (Size j{1}; j <= n; ++j)
-                    correctorSum += correctorWeights[n - j] * f[j];
+
+                for (Size j{1}; j <= n; ++j) {
+                    const T& fj{f[j]};
+                    predictorSum += predictorWeights[n - j] * fj;
+                    correctorSum += correctorWeights[n - j] * fj;
+                }
+
+                const T yP{y0 + dtAlpha / gamma1 * predictorSum};
                 correctorSum += ode(tNext, yP);
 
                 y[n + 1] = y0 + dtAlpha / gamma2 * correctorSum;


### PR DESCRIPTION
`FractionalAdams::solve` ran two separate reductions over the same `f[0..n]`. `correctorSum` never depends on `yP`; the `ode(tNext, yP)` term is added after the loop so both accumulate in one pass.

Accumulation order (`j` ascending), the trailing `ode(tNext, yP)` add, and the `ode` call sequence are bit-identical. Verified by diffing hexfloat groups of 1800 rough Heston prices before and after.

Speedup on the in-tree template, complex-valued, alpha = 0.6:

| steps | two-pass | fused  | speedup |
| ----- | -------- | ------ | ------- |
| 256   | 32.1 us  | 30.6 us | 1.05x  |
| 1024  | 436 us   | 389 us  | 1.12x  |
| 4096  | 6865 us  | 6074 us | 1.13x  |