### PR TITLE
Use `enum` instead of `enum class` for a couple of inner enumerations

### DIFF
--- a/ql/experimental/fx/mtmcrosscurrencybasisswap.hpp
+++ b/ql/experimental/fx/mtmcrosscurrencybasisswap.hpp
@@ -74,7 +74,7 @@ class MtMCrossCurrencyBasisSwap : public CrossCurrencySwap {
     class results;
     class engine;
 
-    enum class Type { PayFxBaseCurrency, ReceiveFxBaseCurrency };
+    enum Type { PayFxBaseCurrency, ReceiveFxBaseCurrency };
 
     //! \name Constructors
     //@{
@@ -146,7 +146,7 @@ class MtMCrossCurrencyBasisSwap : public CrossCurrencySwap {
     //@{
     Type type() const { return type_; }
 
-    bool paysFxBaseCurrency() const { return type_ == Type::PayFxBaseCurrency; }
+    bool paysFxBaseCurrency() const { return type_ == PayFxBaseCurrency; }
 
     Real fxBaseNominal() const { return fxBaseNominal_; }
     const Currency& fxBaseCurrency() const { return fxBaseCurrency_; }

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -377,7 +377,7 @@ namespace QuantLib {
         // zero spreads and spot FX = 1, so that its fair spread on the basis
         // leg reproduces the helper quote.  It pays the base-currency leg.
         swap_ = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-            MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency,
+            MtMCrossCurrencyBasisSwap::PayFxBaseCurrency,
             1.0, baseCcyIdx_->currency(), baseCcySchedule_, baseCcyIdx_, 0.0, 1.0,
             1.0, quoteCcyIdx_->currency(), quoteCcySchedule_, quoteCcyIdx_, 0.0, 1.0,
             isFxBaseCurrencyLegResettable_, fxResetFixingDays_,

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
@@ -189,12 +189,14 @@ namespace QuantLib {
         const std::complex<Real>& z, Time t) const {
 
         switch (approximation_) {
-          case Approximation::Pade:
+          case AdamsPredictorCorrector:
+            return lnChFAdams(z, t);
+          case Pade:
             return lnChFPade(z, t);
-          case Approximation::Lifted:
+          case Lifted:
             return lnChFLifted(z, t);
           default:
-            return lnChFAdams(z, t);
+            QL_FAIL("unknown approximation: " << approximation_);
         }
     }
 
@@ -525,12 +527,14 @@ namespace QuantLib {
         QL_REQUIRE(t > 0.0, "maturity must be positive");
 
         switch (approximation_) {
-          case Approximation::Pade:
+          case AdamsPredictorCorrector:
+            return solveAdamsRiccati(z, t).back();
+          case Pade:
             return padeRiccati(z, t);
-          case Approximation::Lifted:
+          case Lifted:
             return solveLiftedRiccati(z, t).psi;
           default:
-            return solveAdamsRiccati(z, t).back();
+            QL_FAIL("unknown approximation: " << approximation_);
         }
     }
 

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -93,7 +93,7 @@ namespace QuantLib {
         typedef FourierIntegration Integration;
 
         //! Route used to solve the fractional Riccati equation
-        enum class Approximation { AdamsPredictorCorrector, Pade, Lifted };
+        enum Approximation { AdamsPredictorCorrector, Pade, Lifted };
 
         /*! Constructor using Gauss-Laguerre integration. nFactors is the
             number of exponentials of the lifted kernel and is ignored by
@@ -103,8 +103,7 @@ namespace QuantLib {
             const ext::shared_ptr<RoughHestonModel>& model,
             Size integrationOrder = 128,
             Size timeSteps = 256,
-            Approximation approximation
-                = Approximation::AdamsPredictorCorrector,
+            Approximation approximation = AdamsPredictorCorrector,
             Size nFactors = 20);
 
         /*! Constructor giving full control over the Fourier integration
@@ -117,8 +116,7 @@ namespace QuantLib {
             Size timeSteps = 256,
             Real andersenPiterbargEpsilon = 1e-25,
             Real alpha = -0.5,
-            Approximation approximation
-                = Approximation::AdamsPredictorCorrector,
+            Approximation approximation = AdamsPredictorCorrector,
             Size nFactors = 20);
 
         void update() override;

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -746,7 +746,7 @@ BOOST_AUTO_TEST_CASE(testMtMHelperMatchesStandaloneWithAsymmetricFxHolidays) {
 
     auto helperSwap = helper->swap();
     auto standalone = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency,
         1.0, EURCurrency(), helperSwap->fxBaseSchedule(), eurIndex, 0.0, 1.0,
         1.0, USDCurrency(), helperSwap->fxQuoteSchedule(), usdIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false,
@@ -788,7 +788,7 @@ BOOST_AUTO_TEST_CASE(testMtMHelperMatchesStandaloneWithAsymmetricFxHolidays) {
     // Under the previous zero-day convention the first reset is still in the
     // future and is projected instead of using today's observed fixing.
     auto zeroLagReset = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency,
         1.0, EURCurrency(), helperSwap->fxBaseSchedule(), eurIndex, 0.0, 1.0,
         1.0, USDCurrency(), helperSwap->fxQuoteSchedule(), usdIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false, /*fxResetFixingDays=*/0, /*fxResetFixingCalendar=*/Calendar(),

--- a/test-suite/mtmcrosscurrencybasisswap.cpp
+++ b/test-suite/mtmcrosscurrencybasisswap.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(testFairFxQuoteSpreadRepricesToZero) {
     // Base USD (constant notional), quote EUR (resettable leg).
     auto makeSwap = [&](Spread eurSpread) {
         auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-            MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency,
+            MtMCrossCurrencyBasisSwap::PayFxBaseCurrency,
             usdNominal, USDCurrency(), sch, usdIndex, 0.0, 1.0, eurNominal, EURCurrency(), sch,
             eurIndex, eurSpread, 1.0, /*isFxBaseCurrencyLegResettable=*/false);
         swap->setPricingEngine(engine);
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(testRepricesToParOffHelperBootstrappedCurve) {
                                           .backwards();
 
                     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-                        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, 1.0, EURCurrency(),
+                        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, 1.0, EURCurrency(),
                         eurSch, eurIndex, baseLegBasis, 1.0, 1.0, USDCurrency(), usdSch, usdIndex,
                         quoteLegBasis, 1.0, isFxBaseCurrencyLegResettable, fxResetFixingDays, cal);
                     swap->setPricingEngine(engine);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(testFxResetObservationDatesAndProjection) {
     auto spotQuote = ext::make_shared<SimpleQuote>(spotFx);
     Handle<Quote> spotFxHandle(spotQuote);
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, eurNominal, EURCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, eurNominal, EURCurrency(), sch,
         eurIndex, 0.0, 1.0, eurNominal * spotFx, USDCurrency(), sch, usdIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false, fxResetConvention.fixingDays(), fxResetConvention.fixingCalendar());
     BOOST_CHECK(!swap->fxResetFixingCalendar().empty());
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(testKnownFxResetBeforeAccrualStart) {
 
     Real eurNominal = 10000000.0;
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, eurNominal, EURCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, eurNominal, EURCurrency(), sch,
         eurIndex, 0.0, 1.0, eurNominal * 1.10, USDCurrency(), sch, usdIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false, fxResetConvention.fixingDays(), fxResetConvention.fixingCalendar());
     swap->setPricingEngine(ext::make_shared<DiscountingMtMCrossCurrencyBasisSwapEngine>(
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(testResettableLegCashFlowsMatchLegResults) {
 
     // Base USD (constant notional), quote EUR (resettable leg).
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
         usdIndex, 0.0, 1.0, usdNominal / spotFx, EURCurrency(), sch, eurIndex, 10.0e-4, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false);
     BOOST_CHECK(swap->fxResetFixingCalendar().empty());
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(testSameDayResetUsesSpot) {
     Real usdNominal = 10000000.0;
     Rate spotFx = 1.10;
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
         usdIndex, 0.0, 1.0, usdNominal / spotFx, EURCurrency(), sch, eurIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false);
 
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(testFxSettlementAndNpvDateConsistency) {
 
     auto makeSwap = [&]() {
         return ext::make_shared<MtMCrossCurrencyBasisSwap>(
-            MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
+            MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
             usdIndex, 0.0, 1.0, usdNominal / referenceSpot, EURCurrency(), sch, eurIndex,
             15.0e-4, 1.0, /*isFxBaseCurrencyLegResettable=*/false);
     };
@@ -695,7 +695,7 @@ BOOST_AUTO_TEST_CASE(testSeasonedResetPeriodNeedsExchangeRate) {
         USDCurrency(), usdCurve, EURCurrency(), eurCurve, makeQuoteHandle(spotFx));
 
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency,
         usdNominal, USDCurrency(), sch, usdIndex, 0.0, 1.0, eurNominal, EURCurrency(), sch,
         eurIndex, 0.0, 1.0, /*isFxBaseCurrencyLegResettable=*/true);
     swap->setPricingEngine(engine);
@@ -733,7 +733,7 @@ BOOST_AUTO_TEST_CASE(testSeasonedTriangulatedResetMatchesConstantNotional) {
     Rate realisedFx = 0.92;        // realised EUR per USD at the past reset (deliberately != 1/spotFx)
 
     auto mtm = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch, usdIndex,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch, usdIndex,
         0.0, 1.0, usdNominal / spotFx, EURCurrency(), sch, eurIndex, eurBasis, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false);
 
@@ -807,7 +807,7 @@ BOOST_AUTO_TEST_CASE(testSeasonedEurUsdMarketExchangeRate) {
     // base = EUR (constant), quote = USD (resettable); reset notional = EUR notional * USD per EUR.
     Real realizedUsdNotional = eurNotional * marketFx;
     auto mtm = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, eurNotional, EURCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, eurNotional, EURCurrency(), sch,
         eurIndex, basis, 1.0, realizedUsdNotional, USDCurrency(), sch, usdIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false);
 
@@ -872,7 +872,7 @@ BOOST_AUTO_TEST_CASE(testSeasonedUsdJpyMarketExchangeRate) {
     // base = USD (resettable), quote = JPY (constant); reset notional = JPY notional * USD per JPY.
     Real realizedUsdNotional = jpyNotional / marketFx;
     auto mtm = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, realizedUsdNotional, USDCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, realizedUsdNotional, USDCurrency(), sch,
         usdIndex, 0.0, 1.0, jpyNotional, JPYCurrency(), sch, jpyIndex, basis, 1.0,
         /*isFxBaseCurrencyLegResettable=*/true);
 
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE(testSeasonedOvernightLegsMatchConstantNotional) {
 
     auto spot = makeQuoteHandle(spotFx);
     auto mtm = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
         usdIndex, 0.0, 1.0, usdNominal / spotFx, EURCurrency(), sch, eurIndex, eurBasis, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false);
     mtm->setPricingEngine(ext::make_shared<DiscountingMtMCrossCurrencyBasisSwapEngine>(
@@ -1009,7 +1009,7 @@ BOOST_AUTO_TEST_CASE(testResetExchangePaymentDates) {
     Real usdNominal = 10000000.0;
     Rate spotFx = 1.10;
     auto swap = ext::make_shared<MtMCrossCurrencyBasisSwap>(
-        MtMCrossCurrencyBasisSwap::Type::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
+        MtMCrossCurrencyBasisSwap::PayFxBaseCurrency, usdNominal, USDCurrency(), sch,
         usdIndex, 0.0, 1.0, usdNominal / spotFx, EURCurrency(), sch, eurIndex, 0.0, 1.0,
         /*isFxBaseCurrencyLegResettable=*/false, /*fxResetFixingDays=*/0, /*fxResetFixingCalendar=*/Calendar(),
         /*fxBasePaymentLag=*/2, /*fxQuotePaymentLag=*/2,

--- a/test-suite/roughhestonmodel.cpp
+++ b/test-suite/roughhestonmodel.cpp
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE(testPadeRiccatiAsymptotics) {
             hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::Approximation::Pade)};
+            AnalyticRoughHestonEngine::Pade)};
 
         for (const Real u : {0.5, 2.0, 5.0}) {
             const std::complex<Real> z(u, -0.5);
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE(testPadeTrivialContour) {
             hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::Approximation::Pade)};
+            AnalyticRoughHestonEngine::Pade)};
 
         for (const std::complex<Real> z :
              {std::complex<Real>(0.0, 0.0), std::complex<Real>(0.0, -1.0)}) {
@@ -868,10 +868,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsRiccati) {
 
             const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 1024,
-                AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
+                AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
             const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 256,
-                AnalyticRoughHestonEngine::Approximation::Pade)};
+                AnalyticRoughHestonEngine::Pade)};
 
             Real maxError{0.0};
             // pricing contour z = u - i/2 over the calibration-relevant band
@@ -922,10 +922,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsPricing) {
 
         const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 512,
-            AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
+            AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
         const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::Approximation::Pade)};
+            AnalyticRoughHestonEngine::Pade)};
 
         for (const auto& optionType : {Option::Call, Option::Put}) {
             for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
@@ -980,7 +980,7 @@ BOOST_AUTO_TEST_CASE(testPadeHestonLimit) {
         ext::make_shared<HestonProcess>(rTS, qTS, s0, v0, kappa, theta, sigma, rho),
         0.5)};
     const auto padeEngine{ext::make_shared<AnalyticRoughHestonEngine>(
-        roughModel, 128, 256, AnalyticRoughHestonEngine::Approximation::Pade)};
+        roughModel, 128, 256, AnalyticRoughHestonEngine::Pade)};
 
     const auto hestonModel{ext::make_shared<HestonModel>(
         ext::make_shared<HestonProcess>(
@@ -1046,7 +1046,7 @@ BOOST_AUTO_TEST_CASE(testPadeMonotonicityAndBounds) {
         ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7),
         0.1)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
-        model, 128, 256, AnalyticRoughHestonEngine::Approximation::Pade)};
+        model, 128, 256, AnalyticRoughHestonEngine::Pade)};
 
     // call prices stay monotone, convex and within the no-arbitrage box
     const Time t{1.0};
@@ -1114,7 +1114,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         hurst)};
     const auto trueEngine{ext::make_shared<AnalyticRoughHestonEngine>(
         trueModel, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Approximation::Pade)};
+        AnalyticRoughHestonEngine::Pade)};
 
     std::vector<ext::shared_ptr<CalibrationHelper>> helpers;
     for (const Size months : {3, 6, 12, 24}) {
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         0.2)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
         model, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Approximation::Pade)};
+        AnalyticRoughHestonEngine::Pade)};
 
     for (const auto& helper : helpers)
         ext::static_pointer_cast<BlackCalibrationHelper>(helper)
@@ -1308,13 +1308,13 @@ BOOST_AUTO_TEST_CASE(testLiftedAgainstAdamsRiccati) {
 
             const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 1024,
-                AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
+                AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
 
             Real previousError{QL_MAX_REAL};
             for (const Size n : {10, 40, 160}) {
                 const auto lifted{ext::make_shared<AnalyticRoughHestonEngine>(
                     model, 128, 512,
-                    AnalyticRoughHestonEngine::Approximation::Lifted, n)};
+                    AnalyticRoughHestonEngine::Lifted, n)};
 
                 Real maxError{0.0};
                 for (const Real u : {0.5, 1.0, 2.0, 5.0, 10.0, 20.0}) {
@@ -1385,7 +1385,7 @@ BOOST_AUTO_TEST_CASE(testLiftedHestonLimit) {
         0.5)};
     const auto lifted{ext::make_shared<AnalyticRoughHestonEngine>(
         roughModel, 128, 256,
-        AnalyticRoughHestonEngine::Approximation::Lifted)};
+        AnalyticRoughHestonEngine::Lifted)};
 
     const auto hestonModel{ext::make_shared<HestonModel>(
         ext::make_shared<HestonProcess>(
@@ -1443,13 +1443,13 @@ BOOST_AUTO_TEST_CASE(testLiftedAgainstAdamsPricing) {
 
         const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 1024,
-            AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
+            AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
 
         Real previousError{QL_MAX_REAL};
         for (const Size n : {10, 40, 160}) {
             const auto lifted{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 512,
-                AnalyticRoughHestonEngine::Approximation::Lifted, n)};
+                AnalyticRoughHestonEngine::Lifted, n)};
 
             Real maxError{0.0};
             for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
@@ -1515,7 +1515,7 @@ BOOST_AUTO_TEST_CASE(testLiftedCalibration) {
         hurst)};
     const auto trueEngine{ext::make_shared<AnalyticRoughHestonEngine>(
         trueModel, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Approximation::Lifted, nFactors)};
+        AnalyticRoughHestonEngine::Lifted, nFactors)};
 
     std::vector<ext::shared_ptr<CalibrationHelper>> helpers;
     for (const Size months : {3, 6, 12, 24}) {
@@ -1546,7 +1546,7 @@ BOOST_AUTO_TEST_CASE(testLiftedCalibration) {
         0.2)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
         model, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Approximation::Lifted, nFactors)};
+        AnalyticRoughHestonEngine::Lifted, nFactors)};
 
     for (const auto& helper : helpers)
         ext::static_pointer_cast<BlackCalibrationHelper>(helper)


### PR DESCRIPTION
Namely, `MtMCrossCurrencyBasisSwap::Type` and `AnalyticRoughHestonEngine::Approximation`.  They are already scoped inside the class so there's no name leak into the global namespace; and most of all, using `enum class` with SWIG results in Python pseudo-enums that are way too verbose.