### PR TITLE
Deprecate most optional arguments in `MakeVanillaSwap` constructor and similar

### DIFF
--- a/Examples/CVAIRS/CVAIRS.cpp
+++ b/Examples/CVAIRS/CVAIRS.cpp
@@ -160,9 +160,8 @@ int main(int, char* []) {
         riskySwaps.reserve(sizeof(tenorsSwapMkt)/sizeof(Size));
         for(Size i=0; i<sizeof(tenorsSwapMkt)/sizeof(Size); i++) 
             riskySwaps.push_back(MakeVanillaSwap(tenorsSwapMkt[i]*Years,
-                yieldIndxS,
-                ratesSwapmkt[i], 
-                0*Days)
+                                                 yieldIndxS)
+            .withFixedRate(ratesSwapmkt[i])
             .withSettlementDays(2)
             .withFixedLegDayCount(fixedLegDayCounter)
             .withFixedLegTenor(Period(fixedLegFrequency))

--- a/ql/experimental/swaptions/haganirregularswaptionengine.cpp
+++ b/ql/experimental/swaptions/haganirregularswaptionengine.cpp
@@ -201,7 +201,8 @@ namespace QuantLib {
         // compute annuity transformed rate
         Rate transformedRate = (fairRates_[i] + lambda_) * annuities_[i] / stdAnnuity;
 
-        memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex, transformedRate)
+        memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex)
+                          .withFixedRate(transformedRate)
                           .withType(swap_->type())
                           .withEffectiveDate(swap_->startDate())
                           .withTerminationDate(expiries_[i])

--- a/ql/indexes/swapindex.cpp
+++ b/ql/indexes/swapindex.cpp
@@ -82,7 +82,8 @@ namespace QuantLib {
         if (lastFixingDate_!=fixingDate) {
             Rate fixedRate = 0.0;
             if (exogenousDiscount_)
-                lastSwap_ = MakeVanillaSwap(tenor_, iborIndex_, fixedRate)
+                lastSwap_ = MakeVanillaSwap(tenor_, iborIndex_)
+                    .withFixedRate(fixedRate)
                     .withEffectiveDate(valueDate(fixingDate))
                     .withFixedLegCalendar(fixingCalendar())
                     .withFixedLegDayCount(dayCounter_)
@@ -91,7 +92,8 @@ namespace QuantLib {
                     .withFixedLegTerminationDateConvention(fixedLegConvention_)
                     .withDiscountingTermStructure(discount_);
             else
-                lastSwap_ = MakeVanillaSwap(tenor_, iborIndex_, fixedRate)
+                lastSwap_ = MakeVanillaSwap(tenor_, iborIndex_)
+                    .withFixedRate(fixedRate)
                     .withEffectiveDate(valueDate(fixingDate))
                     .withFixedLegCalendar(fixingCalendar())
                     .withFixedLegDayCount(dayCounter_)

--- a/ql/indexes/swapindex.cpp
+++ b/ql/indexes/swapindex.cpp
@@ -208,7 +208,8 @@ namespace QuantLib {
         // caching mechanism
         if (lastFixingDate_!=fixingDate) {
             Rate fixedRate = 0.0;
-            lastSwap_ = MakeOIS(tenor_, overnightIndex_, fixedRate)
+            lastSwap_ = MakeOIS(tenor_, overnightIndex_)
+                .withFixedRate(fixedRate)
                 .withEffectiveDate(valueDate(fixingDate))
                 .withFixedLegDayCount(dayCounter_)
                 .withTelescopicValueDates(telescopicValueDates_)

--- a/ql/instruments/bonds/btp.cpp
+++ b/ql/instruments/bonds/btp.cpp
@@ -147,9 +147,10 @@ namespace QuantLib {
         Rate dummyRate = 0.05;
         for (Size i=0; i<nSwaps_; ++i) {
             swapLengths_[i] = static_cast<Real>(i+1);
-            swaps_[i] = MakeVanillaSwap(
-                swapLengths_[i]*Years, euriborIndex_, dummyRate, 1*Days)
-                                .withDiscountingTermStructure(discountCurve_);
+            swaps_[i] = MakeVanillaSwap(swapLengths_[i]*Years, euriborIndex_)
+                .withFixedRate(dummyRate)
+                .withForwardStart(1*Days)
+                .withDiscountingTermStructure(discountCurve_);
         }
     }
 

--- a/ql/instruments/makecapfloor.cpp
+++ b/ql/instruments/makecapfloor.cpp
@@ -35,7 +35,9 @@ namespace QuantLib {
       // setting the fixed leg tenor avoids that MakeVanillaSwap throws
       // because of an unknown fixed leg default tenor for a currency,
       // notice that only the floating leg of the swap is used anyway
-      makeVanillaSwap_(MakeVanillaSwap(tenor, iborIndex, 0.0, forwardStart)
+      makeVanillaSwap_(MakeVanillaSwap(tenor, iborIndex)
+                           .withFixedRate(0.0)
+                           .withForwardStart(forwardStart)
                            .withFixedLegTenor(1 * Years)
                            .withFixedLegDayCount(Actual365Fixed())) {}
 

--- a/ql/instruments/makecapfloor.cpp
+++ b/ql/instruments/makecapfloor.cpp
@@ -28,18 +28,25 @@ namespace QuantLib {
 
     MakeCapFloor::MakeCapFloor(CapFloor::Type capFloorType,
                                const Period& tenor,
-                               const ext::shared_ptr<IborIndex>& iborIndex,
-                               Rate strike,
-                               const Period& forwardStart)
-    : capFloorType_(capFloorType), strike_(strike), firstCapletExcluded_(forwardStart == 0 * Days),
+                               const ext::shared_ptr<IborIndex>& iborIndex)
+    : capFloorType_(capFloorType),
       // setting the fixed leg tenor avoids that MakeVanillaSwap throws
       // because of an unknown fixed leg default tenor for a currency,
       // notice that only the floating leg of the swap is used anyway
       makeVanillaSwap_(MakeVanillaSwap(tenor, iborIndex)
                            .withFixedRate(0.0)
-                           .withForwardStart(forwardStart)
                            .withFixedLegTenor(1 * Years)
                            .withFixedLegDayCount(Actual365Fixed())) {}
+
+    MakeCapFloor::MakeCapFloor(CapFloor::Type capFloorType,
+                               const Period& tenor,
+                               const ext::shared_ptr<IborIndex>& iborIndex,
+                               Rate strike,
+                               const Period& forwardStart)
+    : MakeCapFloor(capFloorType, tenor, iborIndex) {
+        withStrike(strike);
+        withForwardStart(forwardStart);
+    }
 
     MakeCapFloor::operator CapFloor() const {
         ext::shared_ptr<CapFloor> capfloor = *this;
@@ -98,6 +105,17 @@ namespace QuantLib {
 
     MakeCapFloor& MakeCapFloor::withNominal(Real n) {
         makeVanillaSwap_.withNominal(n);
+        return *this;
+    }
+
+    MakeCapFloor& MakeCapFloor::withStrike(Rate k) {
+        strike_ = k;
+        return *this;
+    }
+
+    MakeCapFloor& MakeCapFloor::withForwardStart(const Period& f) {
+        makeVanillaSwap_.withForwardStart(f);
+        firstCapletExcluded_ = (f == 0 * Days);
         return *this;
     }
 

--- a/ql/instruments/makecapfloor.hpp
+++ b/ql/instruments/makecapfloor.hpp
@@ -30,7 +30,7 @@
 
 namespace QuantLib {
 
-    //! helper class
+    //! cap/floor builder
     /*! This class provides a more comfortable way
         to instantiate standard market cap and floor.
     */
@@ -38,14 +38,24 @@ namespace QuantLib {
       public:
         MakeCapFloor(CapFloor::Type capFloorType,
                      const Period& capFloorTenor,
+                     const ext::shared_ptr<IborIndex>& iborIndex);
+
+        /*! \deprecated Use the other constructor plus withStrike and/or withForwardStart.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other constructor plus withStrike and/or withForwardStart.")]]
+        MakeCapFloor(CapFloor::Type capFloorType,
+                     const Period& capFloorTenor,
                      const ext::shared_ptr<IborIndex>& iborIndex,
-                     Rate strike = Null<Rate>(),
+                     Rate strike,
                      const Period& forwardStart = 0*Days);
 
         operator CapFloor() const;
         operator ext::shared_ptr<CapFloor>() const;
 
         MakeCapFloor& withNominal(Real n);
+        MakeCapFloor& withStrike(Rate k);
+        MakeCapFloor& withForwardStart(const Period& f);
         MakeCapFloor& withEffectiveDate(const Date& effectiveDate,
                                         bool firstCapletExcluded);
         MakeCapFloor& withTenor(const Period& t);
@@ -65,8 +75,8 @@ namespace QuantLib {
                               const ext::shared_ptr<PricingEngine>& engine);
       private:
         CapFloor::Type capFloorType_;
-        Rate strike_;
-        bool firstCapletExcluded_, asOptionlet_ = false;
+        Rate strike_ = Null<Rate>();
+        bool firstCapletExcluded_ = true, asOptionlet_ = false;
 
         MakeVanillaSwap makeVanillaSwap_;
 

--- a/ql/instruments/makecms.cpp
+++ b/ql/instruments/makecms.cpp
@@ -32,49 +32,38 @@ namespace QuantLib {
 
     MakeCms::MakeCms(const Period& swapTenor,
                      const ext::shared_ptr<SwapIndex>& swapIndex,
+                     const ext::shared_ptr<IborIndex>& iborIndex)
+    : swapTenor_(swapTenor), swapIndex_(swapIndex),
+      iborIndex_(iborIndex != nullptr ? iborIndex : swapIndex->iborIndex()),
+      cmsCalendar_(swapIndex_->fixingCalendar()), floatCalendar_(iborIndex_->fixingCalendar()),
+      floatTenor_(iborIndex_->tenor()),
+      floatConvention_(iborIndex_->businessDayConvention()),
+      floatTerminationDateConvention_(iborIndex_->businessDayConvention()),
+      cmsDayCount_(Actual360()), floatDayCount_(iborIndex_->dayCounter()),
+      // arbitrary choice:
+      // engine_(new DiscountingSwapEngine(iborIndex->termStructure())),
+      engine_(new DiscountingSwapEngine(swapIndex_->forwardingTermStructure())) {}
+
+    
+    MakeCms::MakeCms(const Period& swapTenor,
+                     const ext::shared_ptr<SwapIndex>& swapIndex,
                      const ext::shared_ptr<IborIndex>& iborIndex,
                      Spread iborSpread,
                      const Period& forwardStart)
-    : swapTenor_(swapTenor), swapIndex_(swapIndex), iborIndex_(iborIndex), iborSpread_(iborSpread),
-      useAtmSpread_(false), forwardStart_(forwardStart),
-
-      cmsSpread_(0.0), cmsGearing_(1.0), cmsCap_(Null<Real>()), cmsFloor_(Null<Real>()),
-
-
-      cmsCalendar_(swapIndex->fixingCalendar()), floatCalendar_(iborIndex->fixingCalendar()),
-      payCms_(true), nominal_(1.0), cmsTenor_(3 * Months), floatTenor_(iborIndex->tenor()),
-      cmsConvention_(ModifiedFollowing), cmsTerminationDateConvention_(ModifiedFollowing),
-      floatConvention_(iborIndex->businessDayConvention()),
-      floatTerminationDateConvention_(iborIndex->businessDayConvention()),
-      cmsRule_(DateGeneration::Backward), floatRule_(DateGeneration::Backward),
-      cmsEndOfMonth_(false), floatEndOfMonth_(false),
-
-      cmsDayCount_(Actual360()), floatDayCount_(iborIndex->dayCounter()),
-      // arbitrary choice:
-      // engine_(new DiscountingSwapEngine(iborIndex->termStructure())),
-      engine_(new DiscountingSwapEngine(swapIndex->forwardingTermStructure())) {}
+    : MakeCms(swapTenor, swapIndex, iborIndex) {
+        withIborSpread(iborSpread);
+        withForwardStart(forwardStart);
+    }
 
 
     MakeCms::MakeCms(const Period& swapTenor,
                      const ext::shared_ptr<SwapIndex>& swapIndex,
                      Spread iborSpread,
                      const Period& forwardStart)
-    : swapTenor_(swapTenor), swapIndex_(swapIndex), iborIndex_(swapIndex->iborIndex()),
-      iborSpread_(iborSpread), useAtmSpread_(false), forwardStart_(forwardStart),
-
-      cmsSpread_(0.0), cmsGearing_(1.0), cmsCap_(Null<Real>()), cmsFloor_(Null<Real>()),
-
-
-      cmsCalendar_(swapIndex->fixingCalendar()), floatCalendar_(iborIndex_->fixingCalendar()),
-      payCms_(true), nominal_(1.0), cmsTenor_(3 * Months), floatTenor_(iborIndex_->tenor()),
-      cmsConvention_(ModifiedFollowing), cmsTerminationDateConvention_(ModifiedFollowing),
-      floatConvention_(iborIndex_->businessDayConvention()),
-      floatTerminationDateConvention_(iborIndex_->businessDayConvention()),
-      cmsRule_(DateGeneration::Backward), floatRule_(DateGeneration::Backward),
-      cmsEndOfMonth_(false), floatEndOfMonth_(false),
-
-      cmsDayCount_(Actual360()), floatDayCount_(iborIndex_->dayCounter()),
-      engine_(new DiscountingSwapEngine(swapIndex->forwardingTermStructure())) {}
+    : MakeCms(swapTenor, swapIndex) {
+        withIborSpread(iborSpread);
+        withForwardStart(forwardStart);
+    }
 
 
     MakeCms::operator Swap() const {
@@ -176,6 +165,16 @@ namespace QuantLib {
 
     MakeCms& MakeCms::withNominal(Real n) {
         nominal_ = n;
+        return *this;
+    }
+
+    MakeCms& MakeCms::withIborSpread(Rate s) {
+        iborSpread_ = s;
+        return *this;
+    }
+
+    MakeCms& MakeCms::withForwardStart(const Period& f) {
+        forwardStart_ = f;
         return *this;
     }
 

--- a/ql/instruments/makecms.hpp
+++ b/ql/instruments/makecms.hpp
@@ -41,13 +41,25 @@ namespace QuantLib {
       public:
         MakeCms(const Period& swapTenor,
                 const ext::shared_ptr<SwapIndex>& swapIndex,
-                const ext::shared_ptr<IborIndex>& iborIndex,
-                Spread iborSpread = 0.0,
-                const Period& forwardStart = 0*Days);
+                const ext::shared_ptr<IborIndex>& iborIndex = {});
 
+        /*! \deprecated Use the other constructor plus withIborSpread and/or withForwardStart.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other constructor plus withIborSpread and/or withForwardStart.")]]
         MakeCms(const Period& swapTenor,
                 const ext::shared_ptr<SwapIndex>& swapIndex,
-                Spread iborSpread = 0.0,
+                const ext::shared_ptr<IborIndex>& iborIndex,
+                Spread iborSpread,
+                const Period& forwardStart = 0*Days);
+
+        /*! \deprecated Use the other constructor plus withIborSpread and/or withForwardStart.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other constructor plus withIborSpread and/or withForwardStart.")]]
+        MakeCms(const Period& swapTenor,
+                const ext::shared_ptr<SwapIndex>& swapIndex,
+                Spread iborSpread,
                 const Period& forwardStart = 0*Days);
 
         operator Swap() const;
@@ -55,6 +67,8 @@ namespace QuantLib {
 
         MakeCms& receiveCms(bool flag = true);
         MakeCms& withNominal(Real n);
+        MakeCms& withIborSpread(Rate s);
+        MakeCms& withForwardStart(const Period& f);
         MakeCms& withEffectiveDate(const Date&);
 
         MakeCms& withCmsLegTenor(const Period& t);
@@ -89,24 +103,24 @@ namespace QuantLib {
         Period swapTenor_;
         ext::shared_ptr<SwapIndex> swapIndex_;
         ext::shared_ptr<IborIndex> iborIndex_;
-        Spread iborSpread_;
-        bool useAtmSpread_;
-        Period forwardStart_;
+        Spread iborSpread_ = 0.0;
+        bool useAtmSpread_ = false;
+        Period forwardStart_ = 0 * Days;
 
-        Spread cmsSpread_;
-        Real cmsGearing_;
-        Rate cmsCap_, cmsFloor_;
+        Spread cmsSpread_ = 0.0;
+        Real cmsGearing_ = 1.0;
+        Rate cmsCap_ = Null<Rate>(), cmsFloor_ = Null<Rate>();
 
         Date effectiveDate_;
         Calendar cmsCalendar_, floatCalendar_;
 
-        bool payCms_;
-        Real nominal_;
-        Period cmsTenor_, floatTenor_;
-        BusinessDayConvention cmsConvention_, cmsTerminationDateConvention_;
+        bool payCms_ = true;
+        Real nominal_ = 1.0;
+        Period cmsTenor_ = 3 * Months, floatTenor_;
+        BusinessDayConvention cmsConvention_ = ModifiedFollowing, cmsTerminationDateConvention_ = ModifiedFollowing;
         BusinessDayConvention floatConvention_, floatTerminationDateConvention_;
-        DateGeneration::Rule cmsRule_, floatRule_;
-        bool cmsEndOfMonth_, floatEndOfMonth_;
+        DateGeneration::Rule cmsRule_ = DateGeneration::Backward, floatRule_ = DateGeneration::Backward;
+        bool cmsEndOfMonth_ = false, floatEndOfMonth_ = false;
         Date cmsFirstDate_, cmsNextToLastDate_;
         Date floatFirstDate_, floatNextToLastDate_;
         DayCounter cmsDayCount_, floatDayCount_;

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -31,14 +31,20 @@
 namespace QuantLib {
 
     MakeOIS::MakeOIS(const Period& swapTenor,
-                     const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                     Rate fixedRate,
-                     const Period& forwardStart)
-    : swapTenor_(swapTenor), overnightIndex_(overnightIndex), fixedRate_(fixedRate),
-      forwardStart_(forwardStart),
+                     const ext::shared_ptr<OvernightIndex>& overnightIndex)
+    : swapTenor_(swapTenor), overnightIndex_(overnightIndex),
       fixedCalendar_(overnightIndex->fixingCalendar()),
       overnightCalendar_(overnightIndex->fixingCalendar()),
       fixedDayCount_(overnightIndex->dayCounter()) {}
+
+    MakeOIS::MakeOIS(const Period& swapTenor,
+                     const ext::shared_ptr<OvernightIndex>& overnightIndex,
+                     Rate fixedRate,
+                     const Period& forwardStart)
+    : MakeOIS(swapTenor, overnightIndex) {
+        withFixedRate(fixedRate);
+        withForwardStart(forwardStart);
+    }
 
     MakeOIS::operator OvernightIndexedSwap() const {
         ext::shared_ptr<OvernightIndexedSwap> ois = *this;
@@ -200,6 +206,16 @@ namespace QuantLib {
 
     MakeOIS& MakeOIS::withNominal(Real n) {
         nominal_ = n;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withFixedRate(Rate k) {
+        fixedRate_ = k;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withForwardStart(const Period& f) {
+        forwardStart_ = f;
         return *this;
     }
 

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -41,8 +41,15 @@ namespace QuantLib {
     class MakeOIS {
       public:
         MakeOIS(const Period& swapTenor,
+                const ext::shared_ptr<OvernightIndex>& overnightIndex);
+
+        /*! \deprecated Use the other constructor plus withFixedRate and/or withForwardStart.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other constructor plus withFixedRate and/or withForwardStart.")]]
+        MakeOIS(const Period& swapTenor,
                 const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                Rate fixedRate = Null<Rate>(),
+                Rate fixedRate,
                 const Period& fwdStart = 0*Days);
 
         operator OvernightIndexedSwap() const;
@@ -51,6 +58,9 @@ namespace QuantLib {
         MakeOIS& receiveFixed(bool flag = true);
         MakeOIS& withType(Swap::Type type);
         MakeOIS& withNominal(Real n);
+        MakeOIS& withFixedRate(Rate k);
+
+        MakeOIS& withForwardStart(const Period& f);
 
         MakeOIS& withSettlementDays(Natural settlementDays);
         MakeOIS& withSettlementCalendar(const Calendar& cal);
@@ -102,8 +112,8 @@ namespace QuantLib {
       private:
         Period swapTenor_;
         ext::shared_ptr<OvernightIndex> overnightIndex_;
-        Rate fixedRate_;
-        Period forwardStart_;
+        Rate fixedRate_ = Null<Rate>();
+        Period forwardStart_ = 0*Days;
 
         Natural settlementDays_ = Null<Natural>();
         Date effectiveDate_, terminationDate_;

--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -127,7 +127,8 @@ namespace QuantLib {
             underlyingSwap_ =
                 (ext::shared_ptr<VanillaSwap>)(
                     MakeVanillaSwap(swapIndex_->tenor(),
-                                    swapIndex_->iborIndex(), usedStrike)
+                                    swapIndex_->iborIndex())
+                    .withFixedRate(usedStrike)
                     .withEffectiveDate(swapIndex_->valueDate(fixingDate_))
                     .withFixedLegCalendar(swapIndex_->fixingCalendar())
                     .withFixedLegDayCount(swapIndex_->dayCounter())

--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -113,7 +113,8 @@ namespace QuantLib {
             underlyingSwap_ =
                 (ext::shared_ptr<OvernightIndexedSwap>)(
                     MakeOIS(swapIndex_->tenor(),
-                            OIswap_index->overnightIndex(), usedStrike)
+                            OIswap_index->overnightIndex())
+                    .withFixedRate(usedStrike)
                     .withEffectiveDate(swapIndex_->valueDate(fixingDate_))
                     .withPaymentCalendar(swapIndex_->fixingCalendar())
                     .withFixedLegDayCount(swapIndex_->dayCounter())

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -38,16 +38,22 @@
 namespace QuantLib {
 
     MakeVanillaSwap::MakeVanillaSwap(const Period& swapTenor,
-                                     const ext::shared_ptr<IborIndex>& index,
-                                     Rate fixedRate,
-                                     const Period& forwardStart)
-    : swapTenor_(swapTenor), iborIndex_(index), fixedRate_(fixedRate), forwardStart_(forwardStart),
+                                     const ext::shared_ptr<IborIndex>& index)
+    : swapTenor_(swapTenor), iborIndex_(index),
       fixedCalendar_(index->fixingCalendar()), floatCalendar_(index->fixingCalendar()),
       floatTenor_(index->tenor()),
       floatConvention_(index->businessDayConvention()),
       floatTerminationDateConvention_(index->businessDayConvention()),
-
       floatDayCount_(index->dayCounter()) {}
+
+    MakeVanillaSwap::MakeVanillaSwap(const Period& swapTenor,
+                                     const ext::shared_ptr<IborIndex>& index,
+                                     Rate fixedRate,
+                                     const Period& forwardStart)
+    : MakeVanillaSwap(swapTenor, index) {
+        withFixedRate(fixedRate);
+        withForwardStart(forwardStart);
+    }
 
     MakeVanillaSwap::operator VanillaSwap() const {
         ext::shared_ptr<VanillaSwap> swap = *this;
@@ -214,6 +220,16 @@ namespace QuantLib {
 
     MakeVanillaSwap& MakeVanillaSwap::withNominal(Real n) {
         nominal_ = n;
+        return *this;
+    }
+
+    MakeVanillaSwap& MakeVanillaSwap::withFixedRate(Rate k) {
+        fixedRate_ = k;
+        return *this;
+    }
+
+    MakeVanillaSwap& MakeVanillaSwap::withForwardStart(const Period& f) {
+        forwardStart_ = f;
         return *this;
     }
 

--- a/ql/instruments/makevanillaswap.hpp
+++ b/ql/instruments/makevanillaswap.hpp
@@ -32,15 +32,22 @@
 
 namespace QuantLib {
 
-    //! helper class
+    //! vanilla-swap builder
     /*! This class provides a more comfortable way
-        to instantiate standard market swap.
+        to instantiate a standard market swap.
     */
     class MakeVanillaSwap {
       public:
         MakeVanillaSwap(const Period& swapTenor,
+                        const ext::shared_ptr<IborIndex>& iborIndex);
+
+        /*! \deprecated Use the other constructor plus withFixedRate and/or withForwardStart.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other constructor plus withFixedRate and/or withForwardStart.")]]
+        MakeVanillaSwap(const Period& swapTenor,
                         const ext::shared_ptr<IborIndex>& iborIndex,
-                        Rate fixedRate = Null<Rate>(),
+                        Rate fixedRate,
                         const Period& forwardStart = 0*Days);
 
         operator VanillaSwap() const;
@@ -49,7 +56,9 @@ namespace QuantLib {
         MakeVanillaSwap& receiveFixed(bool flag = true);
         MakeVanillaSwap& withType(Swap::Type type);
         MakeVanillaSwap& withNominal(Real n);
+        MakeVanillaSwap& withFixedRate(Rate k);
 
+        MakeVanillaSwap& withForwardStart(const Period& f);
         MakeVanillaSwap& withSettlementDays(Natural settlementDays);
         MakeVanillaSwap& withSettlementCalendar(const Calendar& cal);
         MakeVanillaSwap& withEffectiveDate(const Date&);
@@ -90,8 +99,9 @@ namespace QuantLib {
       private:
         Period swapTenor_;
         ext::shared_ptr<IborIndex> iborIndex_;
-        Rate fixedRate_;
-        Period forwardStart_;
+
+        Rate fixedRate_ = Null<Rate>();
+        Period forwardStart_ = 0*Days;
 
         Natural settlementDays_ = Null<Natural>();
         Date effectiveDate_, terminationDate_;

--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -166,9 +166,8 @@ namespace QuantLib {
 	    - swapletStart.serialNumber(), Days);
       ext::shared_ptr<VanillaSwap> swaplet = MakeVanillaSwap(
         baseSwapsTenor,
-        swapIndex, 
-        baseSwapFairRate // strike
-        )
+        swapIndex)
+        .withFixedRate(baseSwapFairRate)
 	    .withType(arguments_.type)
 	    .withNominal(arguments_.nominal)
           ////////	    .withSettlementDays(2)
@@ -176,9 +175,8 @@ namespace QuantLib {
         .withTerminationDate(arguments_.fixedPayDates.back());
       ext::shared_ptr<VanillaSwap> revSwaplet = MakeVanillaSwap(
         baseSwapsTenor,
-        swapIndex, 
-        baseSwapFairRate // strike
-        )
+        swapIndex)
+        .withFixedRate(baseSwapFairRate)
 	    .withType(reversedType)
 	    .withNominal(arguments_.nominal)
           /////////	    .withSettlementDays(2)

--- a/ql/termstructures/volatility/gaussian1dsmilesection.cpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.cpp
@@ -58,7 +58,7 @@ namespace QuantLib {
 
         atm_ = model_->forwardRate(fixingDate_, Date(), 0.0, iborIndex_);
         CapFloor c =
-            MakeCapFloor(CapFloor::Cap, iborIndex_->tenor(), iborIndex_, Null<Real>(), 0 * Days)
+            MakeCapFloor(CapFloor::Cap, iborIndex_->tenor(), iborIndex_)
                 .withEffectiveDate(fixingDate_, false);
         annuity_ = iborIndex_->dayCounter().yearFraction(c.startDate(), c.maturityDate()) *
                    model_->zerobond(c.maturityDate());
@@ -86,7 +86,8 @@ Real Gaussian1dSmileSection::optionPrice(Rate strike, Option::Type type,
     } else {
         CapFloor c =
             MakeCapFloor(type == Option::Call ? CapFloor::Cap : CapFloor::Floor,
-                         iborIndex_->tenor(), iborIndex_, strike, 0 * Days)
+                         iborIndex_->tenor(), iborIndex_)
+                .withStrike(strike)
                 .withEffectiveDate(fixingDate_, false)
                 .withPricingEngine(engine_);
         Real tmp = c.NPV();

--- a/ql/termstructures/volatility/swaption/cmsmarket.cpp
+++ b/ql/termstructures/volatility/swaption/cmsmarket.cpp
@@ -89,16 +89,13 @@ namespace QuantLib {
                 // never evaluate the spot swap, only its ibor floating leg
                 spotSwaps_[i][j] = MakeCms(swapLengths_[i],
                                            swapIndexes_[j],
-                                           iborIndex_, 0.0,
-                                           Period())
-                                   .operator ext::shared_ptr<Swap>();
+                                           iborIndex_);
                 fwdSwaps_[i][j]  = MakeCms(swapLengths_[i]-start,
                                            swapIndexes_[j],
-                                           iborIndex_, 0.0,
-                                           start)
+                                           iborIndex_)
+                                   .withForwardStart(start)
                                    .withCmsCouponPricer(pricers_[j])
-                                   .withDiscountingTermStructure(discTS_)
-                                   .operator ext::shared_ptr<Swap>();
+                                   .withDiscountingTermStructure(discTS_);
             }
         }
         // probably useless

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -129,7 +129,9 @@ namespace QuantLib {
         //    i.e. it can dynamically change
         // 2. input discount curve Handle might be empty now but it could
         //    be assigned a curve later; use a RelinkableHandle here
-        auto tmp = MakeOIS(tenor_, overnightIndex_, 0.0, forwardStart_)
+        auto tmp = MakeOIS(tenor_, overnightIndex_)
+            .withFixedRate(0.0)
+            .withForwardStart(forwardStart_)
             .withDiscountingTermStructure(discountRelinkableHandle_)
             .withEffectiveDate(startDate_)
             .withTerminationDate(endDate_)

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -551,7 +551,9 @@ namespace QuantLib {
         //    i.e. it can dynamically change
         // 2. input discount curve Handle might be empty now but it could
         //    be assigned a curve later; use a RelinkableHandle here
-        auto tmp = MakeVanillaSwap(tenor_, iborIndex_, 0.0, fwdStart_)
+        auto tmp = MakeVanillaSwap(tenor_, iborIndex_)
+            .withFixedRate(0.0)
+            .withForwardStart(fwdStart_)
             .withEffectiveDate(startDate_)
             .withTerminationDate(endDate_)
             .withDiscountingTermStructure(discountRelinkableHandle_)

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -322,7 +322,8 @@ BOOST_AUTO_TEST_CASE(testTreeEngineTimeSnapping) {
 
     auto makeBermudanSwaption = [&index](Date callDate) {
         auto effectiveDate = Date(15, May, 2025);
-        ext::shared_ptr<VanillaSwap> swap = MakeVanillaSwap(Period(10, Years), index, 0.05)
+        ext::shared_ptr<VanillaSwap> swap = MakeVanillaSwap(Period(10, Years), index)
+                                                .withFixedRate(0.05)
                                                 .withEffectiveDate(effectiveDate)
                                                 .withNominal(10000.00)
                                                 .withType(Swap::Type::Payer);

--- a/test-suite/cms.cpp
+++ b/test-suite/cms.cpp
@@ -335,8 +335,9 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
         // no gearing, spread
         cms[i] = MakeCms(Period(swapLengths[i], Years),
                          swapIndex,
-                         vars.iborIndex, spread,
-                         10*Days);
+                         vars.iborIndex)
+            .withIborSpread(spread)
+            .withForwardStart(10*Days);
 
     for (Size j=0; j<vars.yieldCurveModels.size(); ++j) {
         vars.numericalPricers[j]->setSwaptionVolatility(vars.atmVol);

--- a/test-suite/cms_normal.cpp
+++ b/test-suite/cms_normal.cpp
@@ -362,7 +362,8 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
         // no gearing, spread
         cms[i] = MakeCms(Period(swapLengths[i], Years),
                          swapIndex,
-                         vars.iborIndex, spread);
+                         vars.iborIndex)
+            .withIborSpread(spread);
 
     for (Size j=0; j<vars.yieldCurveModels.size(); ++j) {
         vars.numericalPricers[j]->setSwaptionVolatility(vars.atmVol);

--- a/test-suite/gsr.cpp
+++ b/test-suite/gsr.cpp
@@ -608,7 +608,8 @@ BOOST_AUTO_TEST_CASE(testGsrModel) {
 
     ext::shared_ptr<VanillaSwap> underlying = swpIdx->underlyingSwap(expiry);
     ext::shared_ptr<VanillaSwap> underlyingFixed =
-        MakeVanillaSwap(10 * Years, swpIdx->iborIndex(), forward)
+        MakeVanillaSwap(10 * Years, swpIdx->iborIndex())
+            .withFixedRate(forward)
             .withEffectiveDate(swpIdx->valueDate(expiry))
             .withFixedLegCalendar(swpIdx->fixingCalendar())
             .withFixedLegDayCount(swpIdx->dayCounter())
@@ -730,7 +731,8 @@ BOOST_AUTO_TEST_CASE(testGsrModelQuoteUpdate) {
     Real forward = swpIdx->fixing(expiry);
 
     ext::shared_ptr<VanillaSwap> underlyingFixed =
-        MakeVanillaSwap(10 * Years, swpIdx->iborIndex(), forward)
+        MakeVanillaSwap(10 * Years, swpIdx->iborIndex())
+            .withFixedRate(forward)
             .withEffectiveDate(swpIdx->valueDate(expiry))
             .withFixedLegCalendar(swpIdx->fixingCalendar())
             .withFixedLegDayCount(swpIdx->dayCounter())

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1173,14 +1173,14 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
     for (Size i = 0; i < outputs1.expiries_.size(); i++) {
         for (Size j = 0; j < outputs1.smileStrikes_[0].size(); j++) {
             ext::shared_ptr<VanillaSwap> underlyingCall =
-                MakeVanillaSwap(outputs1.tenors_[i], iborIndex1,
-                                outputs1.smileStrikes_[i][j])
+                MakeVanillaSwap(outputs1.tenors_[i], iborIndex1)
+                    .withFixedRate(outputs1.smileStrikes_[i][j])
                     .withEffectiveDate(
                          TARGET().advance(outputs1.expiries_[i], 2, Days))
                     .receiveFixed(false);
             ext::shared_ptr<VanillaSwap> underlyingPut =
-                MakeVanillaSwap(outputs1.tenors_[i], iborIndex1,
-                                outputs1.smileStrikes_[i][j])
+                MakeVanillaSwap(outputs1.tenors_[i], iborIndex1)
+                    .withFixedRate(outputs1.smileStrikes_[i][j])
                     .withEffectiveDate(
                          TARGET().advance(outputs1.expiries_[i], 2, Days))
                     .receiveFixed(true);
@@ -1290,14 +1290,14 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
     for (Size i = 0; i < outputs3.expiries_.size(); i++) {
         for (Size j = 0; j < outputs3.smileStrikes_[0].size(); j++) {
             ext::shared_ptr<VanillaSwap> underlyingCall =
-                MakeVanillaSwap(outputs3.tenors_[i], iborIndex3,
-                                outputs3.smileStrikes_[i][j])
+                MakeVanillaSwap(outputs3.tenors_[i], iborIndex3)
+                    .withFixedRate(outputs3.smileStrikes_[i][j])
                     .withEffectiveDate(
                          TARGET().advance(outputs3.expiries_[i], 2, Days))
                     .receiveFixed(false);
             ext::shared_ptr<VanillaSwap> underlyingPut =
-                MakeVanillaSwap(outputs3.tenors_[i], iborIndex3,
-                                outputs3.smileStrikes_[i][j])
+                MakeVanillaSwap(outputs3.tenors_[i], iborIndex3)
+                    .withFixedRate(outputs3.smileStrikes_[i][j])
                     .withEffectiveDate(
                          TARGET().advance(outputs3.expiries_[i], 2, Days))
                     .receiveFixed(true);
@@ -1677,7 +1677,8 @@ BOOST_AUTO_TEST_CASE(testBermudanSwaption) {
         new Gaussian1dSwaptionEngine(mf1, 64, 7.0));
 
     ext::shared_ptr<VanillaSwap> underlyingCall =
-        MakeVanillaSwap(10 * Years, iborIndex1, 0.03)
+        MakeVanillaSwap(10 * Years, iborIndex1)
+            .withFixedRate(0.03)
             .withEffectiveDate(TARGET().advance(referenceDate, 2, Days))
         //.withNominal(100000000.0)
             .receiveFixed(false);

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1234,20 +1234,20 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
     ext::shared_ptr<Gaussian1dCapFloorEngine> mfCapFloorEngine2(
         new Gaussian1dCapFloorEngine(mf2, 64, 7.0));
     std::vector<CapFloor> c2 = {
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.01),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.02),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.03),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.04),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.05),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.07),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.10),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.01),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.02),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.03),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.04),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.05),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.07),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2, 0.10)
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.01),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.02),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.03),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.04),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.05),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.07),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2).withStrike(0.10),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.01),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.02),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.03),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.04),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.05),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.07),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex2).withStrike(0.10)
     };
 
     for (auto& i : c2) {
@@ -1366,22 +1366,22 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
         new Gaussian1dCapFloorEngine(mf4, 64, 7.0));
 
     std::vector<CapFloor> c4 = {
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.01),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.02),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.03),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.04),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.05),
-        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.06),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.01),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.02),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.03),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.04),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.05),
+        MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.06),
         // //exclude because caplet stripper fails for this strike
-        // MakeCapFloor(CapFloor::Cap,5*Years,iborIndex4,0.10),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.01),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.02),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.03),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.04),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.05),
-        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4, 0.06)
+        // MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4).withStrike(0.10),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.01),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.02),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.03),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.04),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.05),
+        MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.06)
         // //exclude because caplet stripper fails for this strike
-        // MakeCapFloor(CapFloor::Floor,5*Years,iborIndex4,0.10)
+        // MakeCapFloor(CapFloor::Floor, 5 * Years, iborIndex4).withStrike(0.10)
     };
 
     for (auto& i : c4) {

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -537,9 +537,8 @@ BOOST_AUTO_TEST_CASE(testFlatTermVolatilityStripping1) {
         for (Size strikeIndex=0; strikeIndex<vars.strikes.size(); ++strikeIndex) {
             cap = MakeCapFloor(CapFloor::Cap,
                                vars.optionTenors[tenorIndex],
-                               iborIndex,
-                               vars.strikes[strikeIndex],
-                               0*Days)
+                               iborIndex)
+                  .withStrike(vars.strikes[strikeIndex])
                   .withPricingEngine(strippedVolEngine);
 
             Real priceFromStrippedVolatility = cap->NPV();
@@ -598,9 +597,8 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1) {
         for (Size strikeIndex=0; strikeIndex<vars.strikes.size(); ++strikeIndex) {
             cap = MakeCapFloor(CapFloor::Cap,
                                vars.optionTenors[tenorIndex],
-                               iborIndex,
-                               vars.strikes[strikeIndex],
-                               0*Days)
+                               iborIndex)
+                  .withStrike(vars.strikes[strikeIndex])
                   .withPricingEngine(strippedVolEngine);
 
             Real priceFromStrippedVolatility = cap->NPV();
@@ -659,8 +657,9 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingNormalVol) {
         for (Size strikeIndex = 0; strikeIndex < vars.strikes.size();
              ++strikeIndex) {
             cap = MakeCapFloor(CapFloor::Cap, vars.optionTenors[tenorIndex],
-                               iborIndex, vars.strikes[strikeIndex],
-                               0 * Days).withPricingEngine(strippedVolEngine);
+                               iborIndex)
+                .withStrike(vars.strikes[strikeIndex])
+                .withPricingEngine(strippedVolEngine);
 
             Real priceFromStrippedVolatility = cap->NPV();
 
@@ -727,8 +726,9 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingShiftedLogNormalVol) {
         for (Size tenorIndex = 0; tenorIndex < vars.optionTenors.size();
              ++tenorIndex) {
             cap = MakeCapFloor(CapFloor::Cap, vars.optionTenors[tenorIndex],
-                               iborIndex, vars.strikes[strikeIndex],
-                               0 * Days).withPricingEngine(strippedVolEngine);
+                               iborIndex)
+                .withStrike(vars.strikes[strikeIndex])
+                .withPricingEngine(strippedVolEngine);
 
             Real priceFromStrippedVolatility = cap->NPV();
 
@@ -1242,8 +1242,8 @@ namespace {
         const std::vector<Rate> strikes = stripper2->atmCapFloorStrikes();
         const std::vector<Real> targetPrices = stripper2->atmCapFloorPrices();
         ext::shared_ptr<CapFloor> cap =
-            MakeCapFloor(CapFloor::Cap, tenors.front(), iborIndex,
-                         strikes.front(), 0 * Days)
+            MakeCapFloor(CapFloor::Cap, tenors.front(), iborIndex)
+                .withStrike(strikes.front())
                 .withPricingEngine(engine);
         QL_CHECK_SMALL(cap->NPV() - targetPrices.front(), vars.tolerance);
     }
@@ -1309,7 +1309,8 @@ BOOST_AUTO_TEST_CASE(testIborReferenceDateCompatibility) {
             CapFloor::Type type = vars.strikes[j] < stripper1->switchStrike()
                                       ? CapFloor::Floor : CapFloor::Cap;
             ext::shared_ptr<CapFloor> legacyCap =
-                MakeCapFloor(type, capFloorLength, iborIndex, vars.strikes[j], 0 * Days)
+                MakeCapFloor(type, capFloorLength, iborIndex)
+                    .withStrike(vars.strikes[j])
                     .withPricingEngine(legacyEngine);
             QL_CHECK_SMALL(
                 capFloorPrices[i][j] - legacyCap->NPV(), 1.0e-12);
@@ -1330,8 +1331,8 @@ BOOST_AUTO_TEST_CASE(testIborReferenceDateCompatibility) {
     volQuote->setValue(0.18);
     for (Size i=0; i<vars.optionTenors.size(); ++i) {
         ext::shared_ptr<CapFloor> legacyCap =
-            MakeCapFloor(CapFloor::Cap, vars.optionTenors[i], iborIndex,
-                         atmStrikes[i], 0 * Days)
+            MakeCapFloor(CapFloor::Cap, vars.optionTenors[i], iborIndex)
+                .withStrike(atmStrikes[i])
                 .withPricingEngine(legacyEngine);
         QL_CHECK_SMALL(atmPrices[i] - legacyCap->NPV(), 1.0e-12);
     }

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -162,7 +162,8 @@ struct CommonVars {
              Integer paymentLag = 0,
              RateAveraging::Type averagingMethod = RateAveraging::Compound,
              const std::optional<Integer>& roundingPrecision = std::nullopt) {
-        return MakeOIS(length, estrIndex, fixedRate, 0 * Days)
+        return MakeOIS(length, estrIndex)
+            .withFixedRate(fixedRate)
             .withEffectiveDate(effectiveDate == Date() ? settlement : effectiveDate)
             .withOvernightLegSpread(spread)
             .withNominal(nominal)
@@ -181,7 +182,8 @@ struct CommonVars {
                          Natural lockoutDays,
                          bool applyObservationShift,
                          bool telescopicValueDates) {
-        return MakeOIS(length, estrIndex, fixedRate, 0 * Days)
+        return MakeOIS(length, estrIndex)
+            .withFixedRate(fixedRate)
             .withEffectiveDate(settlement)
             .withNominal(nominal)
             .withPaymentLag(paymentLag)
@@ -984,7 +986,7 @@ BOOST_AUTO_TEST_CASE(testMakeOISDefaultSettlementDays) {
 
     // Test default settlement days
     for (const auto& [name, index] : indices) {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, index, 0.01);
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, index).withFixedRate(0.01);
         Date expected;
         if (name == "SONIA") {
             expected = today; // T+0 settlement for SONIA
@@ -1000,7 +1002,8 @@ BOOST_AUTO_TEST_CASE(testMakeOISDefaultSettlementDays) {
     for (const auto& [name, index] : indices) {
         // Override settlement days: 2 for CORRA, 1 for all others
         Natural settlementDaysOverride = (name == "CORRA") ? 2 : 1;
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, index, 0.01)
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, index)
+                                        .withFixedRate(0.01)
                                         .withSettlementDays(settlementDaysOverride);
         Date expected = today + settlementDaysOverride * Days;
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
@@ -1012,21 +1015,21 @@ BOOST_AUTO_TEST_CASE(testMakeOISDefaultSettlementDays) {
 
     // Test 0-day settlement index on weekend
     {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[0].second, 0.01); // SONIA
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[0].second).withFixedRate(0.01); // SONIA
         Date expected(12, May, 2025); // Monday
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
 
     // Test 1-day settlement index on weekend
     {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[1].second, 0.01); // CORRA
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[1].second).withFixedRate(0.01); // CORRA
         Date expected(12, May, 2025); // Monday: T+1 from the actual trade date
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
 
     // Test 2-day settlement index on weekend
     {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[2].second, 0.01); // EONIA
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[2].second).withFixedRate(0.01); // EONIA
         Date expected(13, May, 2025); // Tuesday: T+2 from the actual trade date
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
@@ -1129,7 +1132,8 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
     // settlementDays first, then effectiveDate
     BOOST_CHECK_EXCEPTION(
         ext::shared_ptr<OvernightIndexedSwap> swap =
-            MakeOIS(5 * Years, index, 0.03)
+        MakeOIS(5 * Years, index)
+                .withFixedRate(0.03)
                 .withSettlementDays(2)
                 .withEffectiveDate(effectiveDate),
         Error,
@@ -1138,7 +1142,8 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
     // effectiveDate first, then settlementDays
     BOOST_CHECK_EXCEPTION(
         ext::shared_ptr<OvernightIndexedSwap> swap =
-            MakeOIS(5 * Years, index, 0.03)
+        MakeOIS(5 * Years, index)
+                .withFixedRate(0.03)
                 .withEffectiveDate(effectiveDate)
                 .withSettlementDays(2),
         Error,
@@ -1146,19 +1151,22 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
 
     // withSettlementDays alone works
     ext::shared_ptr<OvernightIndexedSwap> swap1 =
-        MakeOIS(5 * Years, index, 0.03)
+        MakeOIS(5 * Years, index)
+            .withFixedRate(0.03)
             .withSettlementDays(2);
     BOOST_CHECK(swap1->startDate() != Date());
 
     // withEffectiveDate alone works
     ext::shared_ptr<OvernightIndexedSwap> swap2 =
-        MakeOIS(5 * Years, index, 0.03)
+        MakeOIS(5 * Years, index)
+            .withFixedRate(0.03)
             .withEffectiveDate(effectiveDate);
     BOOST_CHECK_EQUAL(swap2->startDate(), effectiveDate);
 
     // neither set (constructor defaults) works
     ext::shared_ptr<OvernightIndexedSwap> swap3 =
-        MakeOIS(5 * Years, index, 0.03);
+        MakeOIS(5 * Years, index)
+        .withFixedRate(0.03);
     BOOST_CHECK(swap3->startDate() != Date());
 }
 
@@ -1268,7 +1276,7 @@ BOOST_AUTO_TEST_CASE(testSpotDateFromNonBusinessEvaluationDate) {
     Date expectedStart = calendar.advance(today, 2 * Days);
 
     ext::shared_ptr<OvernightIndexedSwap> swap =
-        MakeOIS(1 * Years, index, 0.03).withSettlementDays(2);
+        MakeOIS(1 * Years, index).withFixedRate(0.03).withSettlementDays(2);
 
     if (swap->startDate() != expectedStart)
         BOOST_FAIL("OIS start date not calculated from the actual "
@@ -1295,7 +1303,8 @@ BOOST_AUTO_TEST_CASE(testSettlementCalendar) {
     Date expectedStart = settlementCalendar.advance(today, 2 * Days);
 
     ext::shared_ptr<OvernightIndexedSwap> swap =
-        MakeOIS(1 * Years, index, 0.03)
+        MakeOIS(1 * Years, index)
+            .withFixedRate(0.03)
             .withSettlementDays(2)
             .withSettlementCalendar(settlementCalendar);
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -381,7 +381,8 @@ void testCurveConsistency(CommonVars& vars,
     for (Size i=0; i<vars.swaps; i++) {
         Period tenor = swapData[i].n*swapData[i].units;
 
-        VanillaSwap swap = MakeVanillaSwap(tenor, euribor6m, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(tenor, euribor6m)
+            .withFixedRate(0.0)
             .withEffectiveDate(vars.settlement)
             .withFixedLegDayCount(vars.fixedLegDayCounter)
             .withFixedLegTenor(Period(vars.fixedLegFrequency))
@@ -906,7 +907,8 @@ BOOST_AUTO_TEST_CASE(testLiborFixing) {
     for (Size i=0; i<vars.swaps; i++) {
         Period tenor = swapData[i].n*swapData[i].units;
 
-        VanillaSwap swap = MakeVanillaSwap(tenor, index, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(tenor, index)
+            .withFixedRate(0.0)
             .withEffectiveDate(vars.settlement)
             .withFixedLegDayCount(vars.fixedLegDayCounter)
             .withFixedLegTenor(Period(vars.fixedLegFrequency))
@@ -939,7 +941,8 @@ BOOST_AUTO_TEST_CASE(testLiborFixing) {
     for (Size i=0; i<vars.swaps; i++) {
         Period tenor = swapData[i].n*swapData[i].units;
 
-        VanillaSwap swap = MakeVanillaSwap(tenor, index, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(tenor, index)
+            .withFixedRate(0.0)
             .withEffectiveDate(vars.settlement)
             .withFixedLegDayCount(vars.fixedLegDayCounter)
             .withFixedLegTenor(Period(vars.fixedLegFrequency))
@@ -1007,7 +1010,8 @@ BOOST_AUTO_TEST_CASE(testJpyLibor) {
     for (Size i=0; i<vars.swaps; i++) {
         Period tenor = swapData[i].n*swapData[i].units;
 
-        VanillaSwap swap = MakeVanillaSwap(tenor, jpylibor6m, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(tenor, jpylibor6m)
+            .withFixedRate(0.0)
             .withEffectiveDate(vars.settlement)
             .withFixedLegDayCount(vars.fixedLegDayCounter)
             .withFixedLegTenor(Period(vars.fixedLegFrequency))
@@ -1185,7 +1189,8 @@ BOOST_AUTO_TEST_CASE(testBadPreviousCurve, *precondition(usingAtParCoupons())) {
     for (auto& i : data) {
         Period tenor = i.n * i.units;
 
-        VanillaSwap swap = MakeVanillaSwap(tenor, index, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(tenor, index)
+            .withFixedRate(0.0)
             .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
             .withFixedLegTenor(Period(1, Months))
             .withFixedLegConvention(Unadjusted);
@@ -1742,7 +1747,8 @@ BOOST_AUTO_TEST_CASE(testMultiCurveTwoPiecewiseYieldCurves) {
     }
 
     for (Size i = 2; i <= 10; ++i) {
-        VanillaSwap swap = MakeVanillaSwap(i * Years, euribor6m, q->value())
+        VanillaSwap swap = MakeVanillaSwap(i * Years, euribor6m)
+                               .withFixedRate(q->value())
                                .withSettlementDays(euribor6m->fixingDays())
                                .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
                                .withFixedLegTenor(1 * Years)
@@ -1800,7 +1806,8 @@ BOOST_AUTO_TEST_CASE(testMultiCurvePiecewiseYieldCurveAndSpreadedCurve) {
     // check instrument npvs
 
     for (Size i = 1; i <= 10; ++i) {
-        VanillaSwap swap = MakeVanillaSwap(i * Years, euribor3m, q->value())
+        VanillaSwap swap = MakeVanillaSwap(i * Years, euribor3m)
+                               .withFixedRate(q->value())
                                .withSettlementDays(euribor3m->fixingDays())
                                .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
                                .withFixedLegTenor(1 * Years)
@@ -1897,7 +1904,8 @@ void testPiecewiseSpreadYieldCurveImpl() {
     const Real tolerance = 1.0e-9;
     euribor3m = ext::make_shared<Euribor3M>(curveHandle);
     for (const auto& datum : swapData) {
-        VanillaSwap swap = MakeVanillaSwap(datum.n * datum.units, euribor3m, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(datum.n * datum.units, euribor3m)
+            .withFixedRate(0.0)
             .withEffectiveDate(vars.settlement)
             .withFixedLegDayCount(vars.fixedLegDayCounter)
             .withFixedLegTenor(Period(vars.fixedLegFrequency))
@@ -2311,7 +2319,8 @@ BOOST_AUTO_TEST_CASE(testDatedSwapHelpers) {
     euribor6m = ext::make_shared<Euribor6M>(h);
 
     for (auto [start, end, q] : swapData) {
-        VanillaSwap swap = MakeVanillaSwap(Period(), euribor6m, 0.0)
+        VanillaSwap swap = MakeVanillaSwap(Period(), euribor6m)
+            .withFixedRate(0.0)
             .withEffectiveDate(start)
             .withTerminationDate(end)
             .withFixedLegDayCount(fixedLegDayCounter)
@@ -2387,7 +2396,9 @@ BOOST_AUTO_TEST_CASE(testSwapRateHelperWithCouponPricer) {
     for (auto& d : swapData) {
         // built to match the helper's internal swap, priced with the same pricer
         ext::shared_ptr<VanillaSwap> swap =
-            MakeVanillaSwap(Period(d.n, d.units), index, d.rate, 0 * Days)
+            MakeVanillaSwap(Period(d.n, d.units), index)
+                .withFixedRate(d.rate)
+                .withForwardStart(0 * Days)
                 .withDiscountingTermStructure(curveHandle)
                 .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
                 .withFixedLegTenor(Period(Annual))

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -398,7 +398,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // GBP 10Y: should infer Semiannual (6M) fixed tenor
     Date endDate10Y = startDate + 10 * Years;
     ext::shared_ptr<VanillaSwap> gbp10Y =
-        MakeVanillaSwap(10 * Years, gbpIndex, 0.03)
+        MakeVanillaSwap(10 * Years, gbpIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate10Y);
     Size gbp10YPeriods = gbp10Y->fixedSchedule().size() - 1;
@@ -409,7 +410,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // GBP 6M: should infer Annual (1Y) fixed tenor
     Date endDate6M = startDate + 6 * Months;
     ext::shared_ptr<VanillaSwap> gbp6M =
-        MakeVanillaSwap(6 * Months, gbpIndex, 0.03)
+        MakeVanillaSwap(6 * Months, gbpIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate6M);
     Size gbp6MPeriods = gbp6M->fixedSchedule().size() - 1;
@@ -420,7 +422,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // AUD 5Y: should infer Semiannual (6M) fixed tenor
     Date endDate5Y = startDate + 5 * Years;
     ext::shared_ptr<VanillaSwap> aud5Y =
-        MakeVanillaSwap(5 * Years, audIndex, 0.03)
+        MakeVanillaSwap(5 * Years, audIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate5Y);
     Size aud5YPeriods = aud5Y->fixedSchedule().size() - 1;
@@ -431,7 +434,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // AUD 2Y: should infer Quarterly (3M) fixed tenor
     Date endDate2Y = startDate + 2 * Years;
     ext::shared_ptr<VanillaSwap> aud2Y =
-        MakeVanillaSwap(2 * Years, audIndex, 0.03)
+        MakeVanillaSwap(2 * Years, audIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate2Y);
     Size aud2YPeriods = aud2Y->fixedSchedule().size() - 1;
@@ -442,7 +446,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // AUD 4Y (boundary): should infer Semiannual (6M) fixed tenor
     Date endDate4Y = startDate + 4 * Years;
     ext::shared_ptr<VanillaSwap> aud4Y =
-        MakeVanillaSwap(4 * Years, audIndex, 0.03)
+        MakeVanillaSwap(4 * Years, audIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate4Y);
     Size aud4YPeriods = aud4Y->fixedSchedule().size() - 1;
@@ -453,7 +458,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // AUD 3Y: should infer Quarterly (3M) fixed tenor
     Date endDate3Y = startDate + 3 * Years;
     ext::shared_ptr<VanillaSwap> aud3Y =
-        MakeVanillaSwap(3 * Years, audIndex, 0.03)
+        MakeVanillaSwap(3 * Years, audIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate3Y);
     Size aud3YPeriods = aud3Y->fixedSchedule().size() - 1;
@@ -464,7 +470,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // GBP 10Y without withEffectiveDate (settlement-derived start date)
     Date endDateSettlement = today + 10 * Years;
     ext::shared_ptr<VanillaSwap> gbpNoEffDate =
-        MakeVanillaSwap(10 * Years, gbpIndex, 0.03)
+        MakeVanillaSwap(10 * Years, gbpIndex)
+            .withFixedRate(0.03)
             .withTerminationDate(endDateSettlement);
     Size gbpNoEffPeriods = gbpNoEffDate->fixedSchedule().size() - 1;
     if (gbpNoEffPeriods != 20)
@@ -474,7 +481,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
     // withTerminationDate clears the constructor tenor, so the
     // date-based inference should use the 10Y span, not the 6M arg
     ext::shared_ptr<VanillaSwap> gbpMismatch =
-        MakeVanillaSwap(6 * Months, gbpIndex, 0.03)
+        MakeVanillaSwap(6 * Months, gbpIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate10Y);
     Size mismatchPeriods = gbpMismatch->fixedSchedule().size() - 1;
@@ -484,7 +492,8 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
 
     // Explicit withFixedLegTenor should always take precedence
     ext::shared_ptr<VanillaSwap> gbpOverride =
-        MakeVanillaSwap(10 * Years, gbpIndex, 0.03)
+        MakeVanillaSwap(10 * Years, gbpIndex)
+            .withFixedRate(0.03)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate10Y)
             .withFixedLegTenor(3 * Months);
@@ -511,7 +520,8 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
     // settlementDays first, then effectiveDate
     BOOST_CHECK_EXCEPTION(
         ext::shared_ptr<VanillaSwap> swap =
-            MakeVanillaSwap(5 * Years, index, 0.03)
+            MakeVanillaSwap(5 * Years, index)
+                .withFixedRate(0.03)
                 .withSettlementDays(2)
                 .withEffectiveDate(effectiveDate),
         Error,
@@ -520,7 +530,8 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
     // effectiveDate first, then settlementDays
     BOOST_CHECK_EXCEPTION(
         ext::shared_ptr<VanillaSwap> swap =
-            MakeVanillaSwap(5 * Years, index, 0.03)
+            MakeVanillaSwap(5 * Years, index)
+                .withFixedRate(0.03)
                 .withEffectiveDate(effectiveDate)
                 .withSettlementDays(2),
         Error,
@@ -528,19 +539,22 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
 
     // withSettlementDays alone works
     ext::shared_ptr<VanillaSwap> swap1 =
-        MakeVanillaSwap(5 * Years, index, 0.03)
+        MakeVanillaSwap(5 * Years, index)
+            .withFixedRate(0.03)
             .withSettlementDays(2);
     BOOST_CHECK(swap1->startDate() != Date());
 
     // withEffectiveDate alone works
     ext::shared_ptr<VanillaSwap> swap2 =
-        MakeVanillaSwap(5 * Years, index, 0.03)
+        MakeVanillaSwap(5 * Years, index)
+            .withFixedRate(0.03)
             .withEffectiveDate(effectiveDate);
     BOOST_CHECK_EQUAL(swap2->startDate(), effectiveDate);
 
     // neither set (constructor defaults) works
     ext::shared_ptr<VanillaSwap> swap3 =
-        MakeVanillaSwap(5 * Years, index, 0.03);
+        MakeVanillaSwap(5 * Years, index)
+            .withFixedRate(0.03);
     BOOST_CHECK(swap3->startDate() != Date());
 }
 
@@ -581,7 +595,8 @@ BOOST_AUTO_TEST_CASE(testSpotDateUsesFixingCalendar) {
     Date expectedStart = index->valueDate(refDate);
 
     ext::shared_ptr<VanillaSwap> swap =
-        MakeVanillaSwap(1 * Years, index, 0.03)
+        MakeVanillaSwap(1 * Years, index)
+            .withFixedRate(0.03)
             .withFixedLegTenor(1 * Years)
             .withFixedLegDayCount(Actual365Fixed())
             .withFloatingLegCalendar(paymentCalendar)
@@ -619,7 +634,9 @@ BOOST_AUTO_TEST_CASE(testSpotDateFromNonBusinessEvaluationDate) {
     Date expectedStart = calendar.advance(today, 2 * Days);
 
     ext::shared_ptr<VanillaSwap> swap =
-        MakeVanillaSwap(5 * Years, index, 0.03).withSettlementDays(2);
+        MakeVanillaSwap(5 * Years, index)
+            .withFixedRate(0.03)
+            .withSettlementDays(2);
 
     if (swap->startDate() != expectedStart)
         BOOST_FAIL("swap start date not calculated from the actual "
@@ -646,7 +663,8 @@ BOOST_AUTO_TEST_CASE(testSettlementCalendar) {
     Date expectedStart = settlementCalendar.advance(today, 2 * Days);
 
     ext::shared_ptr<VanillaSwap> swap =
-        MakeVanillaSwap(5 * Years, index, 0.03)
+        MakeVanillaSwap(5 * Years, index)
+            .withFixedRate(0.03)
             .withSettlementDays(2)
             .withSettlementCalendar(settlementCalendar);
 

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -447,7 +447,8 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
                     "\nexpected:   " << cachedNPV);
 
     ext::shared_ptr<OvernightIndexedSwap> oiswap =
-        MakeOIS(10*Years, vars.oisIndex, 0.06)
+        MakeOIS(10*Years, vars.oisIndex)
+        .withFixedRate(0.06)
         .withEffectiveDate(startDate)
         .withPaymentFrequency(Annual)
         .withFixedLegDayCount(vars.fixedDayCount);
@@ -953,7 +954,8 @@ BOOST_AUTO_TEST_CASE(testImpliedVolatilityOis) {
             for (Real& strike : strikes) {
                 for (auto& k : type) {
                     ext::shared_ptr<OvernightIndexedSwap> swap =
-                        MakeOIS(length, vars.oisIndex, strike)
+                        MakeOIS(length, vars.oisIndex)
+                            .withFixedRate(strike)
                             .withEffectiveDate(startDate)
                             .withPaymentFrequency(Annual)
                             .withFixedLegDayCount(vars.fixedDayCount)

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -153,7 +153,8 @@ BOOST_AUTO_TEST_CASE(testBlackEngineCaching) {
     Date exerciseDate = vars.calendar.advance(vars.today, 1 * Years);
     Date startDate = vars.calendar.advance(exerciseDate, vars.settlementDays, Days);
 
-    ext::shared_ptr<VanillaSwap> swap = MakeVanillaSwap(1 * Years, vars.index, 0.03)
+    ext::shared_ptr<VanillaSwap> swap = MakeVanillaSwap(1 * Years, vars.index)
+                                            .withFixedRate(0.03)
                                             .withEffectiveDate(startDate)
                                             .withFixedLegTenor(1 * Years)
                                             .withFixedLegDayCount(vars.fixedDayCount)
@@ -189,7 +190,8 @@ BOOST_AUTO_TEST_CASE(testStrikeDependency) {
                 Volatility vol = 0.20;
                 for (Real strike : strikes) {
                     ext::shared_ptr<VanillaSwap> swap =
-                        MakeVanillaSwap(length, vars.index, strike)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(strike)
                             .withEffectiveDate(startDate)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
@@ -281,7 +283,8 @@ BOOST_AUTO_TEST_CASE(testSpreadDependency) {
                 std::vector<Real> values_cash;
                 for (Real spread : spreads) {
                     ext::shared_ptr<VanillaSwap> swap =
-                        MakeVanillaSwap(length, vars.index, 0.06)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(0.06)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
                             .withEffectiveDate(startDate)
@@ -364,7 +367,8 @@ BOOST_AUTO_TEST_CASE(testSpreadTreatment) {
                                           vars.settlementDays,Days);
                 for (Real spread : spreads) {
                     ext::shared_ptr<VanillaSwap> swap =
-                        MakeVanillaSwap(length, vars.index, 0.06)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(0.06)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
                             .withEffectiveDate(startDate)
@@ -372,7 +376,8 @@ BOOST_AUTO_TEST_CASE(testSpreadTreatment) {
                             .withType(k);
                     Spread correction = spread * swap->floatingLegBPS() / swap->fixedLegBPS();
                     ext::shared_ptr<VanillaSwap> equivalentSwap =
-                        MakeVanillaSwap(length, vars.index, 0.06 + correction)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(0.06 + correction)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
                             .withEffectiveDate(startDate)
@@ -424,7 +429,8 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
     Date startDate = vars.calendar.advance(exerciseDate,
                                            vars.settlementDays, Days);
     ext::shared_ptr<VanillaSwap> swap =
-        MakeVanillaSwap(10*Years, vars.index, 0.06)
+        MakeVanillaSwap(10*Years, vars.index)
+        .withFixedRate(0.06)
         .withEffectiveDate(startDate)
         .withFixedLegTenor(1*Years)
         .withFixedLegDayCount(vars.fixedDayCount);
@@ -478,7 +484,8 @@ BOOST_AUTO_TEST_CASE(testVega) {
             for (Real strike : strikes) {
                 for (Size h=0; h<std::size(type); h++) {
                     ext::shared_ptr<VanillaSwap> swap =
-                        MakeVanillaSwap(length, vars.index, strike)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(strike)
                             .withEffectiveDate(startDate)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
@@ -847,7 +854,8 @@ BOOST_AUTO_TEST_CASE(testImpliedVolatility) {
             for (Real& strike : strikes) {
                 for (auto& k : type) {
                     ext::shared_ptr<VanillaSwap> swap =
-                        MakeVanillaSwap(length, vars.index, strike)
+                        MakeVanillaSwap(length, vars.index)
+                            .withFixedRate(strike)
                             .withEffectiveDate(startDate)
                             .withFixedLegTenor(1 * Years)
                             .withFixedLegDayCount(vars.fixedDayCount)
@@ -1073,7 +1081,8 @@ void checkSwaptionDelta(bool useBachelierVol)
                         projectionQuoteHandle.linkTo(ext::make_shared<SimpleQuote>(projectionRate));
 
                         ext::shared_ptr<VanillaSwap> underlying =
-                            MakeVanillaSwap(length, idx, strike)
+                            MakeVanillaSwap(length, idx)
+                                .withFixedRate(strike)
                                 .withEffectiveDate(startDate)
                                 .withFixedLegTenor(1 * Years)
                                 .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))


### PR DESCRIPTION
For instance, the forward-start period, which can be passed more readably through a `withForwardStart` method; see the changes in this PR at the point of use.

The same goes for most default arguments in `MakeOIS`, `MakeCapFloor` and `MakeCms`.