### PR TITLE
Avoid iterating over all entries on observable disconnect

### DIFF
--- a/ql/patterns/observable.cpp
+++ b/ql/patterns/observable.cpp
@@ -94,6 +94,7 @@ namespace QuantLib {
 #else
 
 #include <boost/signals2/signal_type.hpp>
+#include <map>
 
 namespace QuantLib {
 
@@ -106,13 +107,24 @@ namespace QuantLib {
                 boost::signals2::keywords::mutex_type<std::recursive_mutex> >
                 ::type signal_type;
 
-            void connect(const signal_type::slot_type& slot) {
-                sig_.connect(slot);
+            /* Keeping each connection under QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN 
+			   avoids searching all entries when an observer unregisters (common for coupons in rate helpers).
+			   This speeds up cleanup for observables materially. */
+            boost::signals2::connection connect(const signal_type::slot_type& slot) {
+                return sig_.connect(slot);
             }
 
-            template <class T>
-            void disconnect(const T& slot) {
-                sig_.disconnect(slot);
+            void store(const void* observer, const boost::signals2::connection& c) {
+                connections_[observer] = c;
+            }
+
+            boost::signals2::connection release(const void* observer) {
+                auto i = connections_.find(observer);
+                if (i == connections_.end())
+                    return {};
+                boost::signals2::connection c = i->second;
+                connections_.erase(i);
+                return c;
             }
 
             void operator()() const {
@@ -120,6 +132,7 @@ namespace QuantLib {
             }
           private:
             signal_type sig_;
+            std::map<const void*, boost::signals2::connection> connections_;
         };
 
         template <class T>
@@ -132,14 +145,6 @@ namespace QuantLib {
             void operator()() const {
                 proxy_->update();
             }
-
-            bool operator==(const ProxyUpdater<T>& other) const {
-                return proxy_ == other.proxy_;
-            }
-
-            bool operator!=(const ProxyUpdater<T>& other) const {
-                return proxy_ != other.proxy_;
-            }
         };
 
     }
@@ -147,22 +152,30 @@ namespace QuantLib {
     void Observable::registerObserver(const ext::shared_ptr<Observer::Proxy>& observerProxy) {
         {
             std::lock_guard<std::recursive_mutex> lock(mutex_);
-            observers_.insert(observerProxy);
+            // an observer registered twice is notified once, as in the
+            // single-threaded implementation
+            if (!observers_.insert(observerProxy).second)
+                return;
         }
 
         detail::Signal::signal_type::slot_type slot {detail::ProxyUpdater<Observer::Proxy>(observerProxy)};
         #if defined(QL_USE_STD_SHARED_PTR)
-        sig_->connect(slot.track_foreign(observerProxy));
+        boost::signals2::connection connection = sig_->connect(slot.track_foreign(observerProxy));
         #else
-        sig_->connect(slot.track(observerProxy));
+        boost::signals2::connection connection = sig_->connect(slot.track(observerProxy));
         #endif
+
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        sig_->store(observerProxy.get(), connection);
     }
 
     void Observable::unregisterObserver(const ext::shared_ptr<Observer::Proxy>& observerProxy,
                                         bool disconnect) {
+        boost::signals2::connection connection;
         {
             std::lock_guard<std::recursive_mutex> lock(mutex_);
             observers_.erase(observerProxy);
+            connection = sig_->release(observerProxy.get());
         }
 
         if (ObservableSettings::instance().updatesDeferred()) {
@@ -171,8 +184,9 @@ namespace QuantLib {
                 ObservableSettings::instance().unregisterDeferredObserver(observerProxy);
         }
 
+        // without disconnect the slot expires with the tracked proxy
         if (disconnect) {
-            sig_->disconnect(detail::ProxyUpdater<Observer::Proxy>(observerProxy));
+            connection.disconnect();
         }
     }
 

--- a/ql/patterns/observable.cpp
+++ b/ql/patterns/observable.cpp
@@ -3,6 +3,7 @@
 /*
 Copyright (C) 2013 Chris Higgs
 Copyright (C) 2015 Klaus Spanderen
+Copyright (C) 2026 Kyrylo Protsenko
 
 This file is part of QuantLib, a free-software/open-source library
 for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2015 Klaus Spanderen
+ Copyright (C) 2026 Kyrylo Protsenko
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -186,6 +186,36 @@ BOOST_AUTO_TEST_CASE(testObservableSettings) {
 }
 
 
+BOOST_AUTO_TEST_CASE(testDuplicateRegistration) {
+    BOOST_TEST_MESSAGE("Testing duplicate observer registration...");
+
+    const ext::shared_ptr<Observable> observable = ext::make_shared<Observable>();
+    UpdateCounter firstObserver;
+    UpdateCounter secondObserver;
+
+    const auto firstRegistration = firstObserver.registerWith(observable);
+    const auto duplicateRegistration = firstObserver.registerWith(observable);
+    secondObserver.registerWith(observable);
+
+    BOOST_CHECK(firstRegistration.second);
+    BOOST_CHECK(!duplicateRegistration.second);
+
+    observable->notifyObservers();
+    BOOST_CHECK_EQUAL(firstObserver.counter(), 1);
+    BOOST_CHECK_EQUAL(secondObserver.counter(), 1);
+
+    BOOST_CHECK_EQUAL(firstObserver.unregisterWith(observable), 1);
+    observable->notifyObservers();
+    BOOST_CHECK_EQUAL(firstObserver.counter(), 1);
+    BOOST_CHECK_EQUAL(secondObserver.counter(), 2);
+
+    BOOST_CHECK(firstObserver.registerWith(observable).second);
+    observable->notifyObservers();
+    BOOST_CHECK_EQUAL(firstObserver.counter(), 2);
+    BOOST_CHECK_EQUAL(secondObserver.counter(), 3);
+}
+
+
 #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
 
 BOOST_AUTO_TEST_CASE(testAsyncGarbagCollector) {


### PR DESCRIPTION
Under QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN, we use boost signal2, and when we disconnect in observable.cpp, we call
sig_.disconnect(slot) but this causes boot signal2 to iterate over all entries.
The problem is that during curve construction when we create helpers with many coupons, we register every coupon (for multiple observables), then unregister it through simplifyNotificationGraph. When we have long maturities and many curves, this creates a significant slowdown.
This fix keeps the connection in the map and during the disconnect it is simply looked up.