### PR TITLE
Fix convexity term in `CashFlows::basisPointValue`

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -1081,7 +1081,7 @@ namespace QuantLib {
                                               includeSettlementDateFlows,
                                               settlementDate, npvDate);
         Real delta = -modifiedDuration*npv;
-        Real gamma = (convexity/100.0)*npv;
+        Real gamma = convexity*npv;
 
         Real shift = 0.0001;
         delta *= shift;

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -1802,11 +1802,10 @@ BOOST_AUTO_TEST_CASE(testBasisPointValue) {
         Real yvbp;
     };
     test_case cases[] = {
-        { Date(), -795.459834, -0.0012571287},
-        { defaultSettlement, -795.459834, -0.0012571287 },
-        { Date(12, February, 2024), -793.149033, -0.0012607913 },
+        { Date(),                   -795.098043, -0.0012571287},
+        { defaultSettlement,       -795.098043, -0.0012571287 },
+        { Date(12, February, 2024), -792.789400, -0.0012607913 },
     };
-
     for (auto& i : cases)
     {
         Real bvp1 = BondFunctions::basisPointValue(fixedRateBond, yield, dayCounter, compounding, frequency, i.settlement);


### PR DESCRIPTION
Description: 'CashFlows::basisPointValue()' was dividing the convexity term by 100, which reduced the second-order contribution by a factor of 100. The implementation is documented as using the second-order Taylor expansion with 'dy = 0.0001': 'dP ≈ P' dy + 1/2 P'' dy²'

Since convexity = P'' / P, the convexity contribution should be convexity * npv without the additional division by 100.

Changes:
1. Removed the incorrect /100.0 factor from the convexity term in CashFlows::basisPointValue().
2. Updated the corresponding bond basis-point-value regression results.

Testing: 
1. Rebuilt QuantLib successfully.
2. Ran the full test suite: 1457 test cases, no errors.