### PR TITLE
Align probability-curve jump handling with the yield-curve implementation

### DIFF
--- a/ql/termstructures/defaulttermstructure.cpp
+++ b/ql/termstructures/defaulttermstructure.cpp
@@ -85,14 +85,16 @@ namespace QuantLib {
 
         if (!jumps_.empty()) {
             Probability jumpEffect = 1.0;
-            for (Size i=0; i<nJumps_ && jumpTimes_[i]<t; ++i) {
-                QL_REQUIRE(jumps_[i]->isValid(),
-                           "invalid " << io::ordinal(i+1) << " jump quote");
-                DiscountFactor thisJump = jumps_[i]->value();
-                QL_REQUIRE(thisJump > 0.0 && thisJump <= 1.0,
-                           "invalid " << io::ordinal(i+1) << " jump value: " <<
-                           thisJump);
-                jumpEffect *= thisJump;
+            for (Size i=0; i<nJumps_; ++i) {
+                if (jumpTimes_[i]>0 && jumpTimes_[i]<t) {
+                    QL_REQUIRE(jumps_[i]->isValid(),
+                               "invalid " << io::ordinal(i+1) << " jump quote");
+                    DiscountFactor thisJump = jumps_[i]->value();
+                    QL_REQUIRE(thisJump > 0.0 && thisJump <= 1.0,
+                               "invalid " << io::ordinal(i+1) << " jump value: " <<
+                               thisJump);
+                    jumpEffect *= thisJump;
+                }
             }
             return jumpEffect * survivalProbabilityImpl(t);
         }

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -28,8 +28,10 @@
 #include <ql/quotes/simplequote.hpp>
 #include <ql/termstructures/credit/defaultprobabilityhelpers.hpp>
 #include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/termstructures/credit/interpolatedhazardratecurve.hpp>
 #include <ql/termstructures/credit/piecewisedefaultcurve.hpp>
 #include <ql/termstructures/yield/discountcurve.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/weekendsonly.hpp>
@@ -526,6 +528,58 @@ BOOST_AUTO_TEST_CASE(testIterativeBootstrapRetries) {
     IterativeBootstrap<SPCurve> ibNoThrow(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0, true, 2);
     dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter, ibNoThrow);
     BOOST_CHECK_NO_THROW(dpts->survivalProbability(testDate));
+}
+
+BOOST_AUTO_TEST_CASE(testJumps) {
+
+    BOOST_TEST_MESSAGE("Testing that credit-curve jumps behave like yield-curve jumps...");
+
+    Date today(15, June, 2024);
+    Settings::instance().evaluationDate() = today;
+    DayCounter dc = Actual365Fixed();
+    double tolerance = 1.0e-10;
+
+    std::vector<Date> dates = {today, today + 10 * 365};
+    std::vector<Rate> rates = {0.02, 0.02};
+
+    // for each scenario the yield curve is the reference: with a flat rate the
+    // jump factor is discount(t) / exp(-0.02 t), and survival should match it.
+    auto ratio = [&](const std::vector<Handle<Quote> >& jumps,
+                     const std::vector<Date>& jumpDates, Time t) {
+        InterpolatedZeroCurve<Linear> yield(dates, rates, dc, Calendar(), jumps, jumpDates);
+        InterpolatedHazardRateCurve<Linear> credit(dates, rates, dc, Calendar(), jumps, jumpDates);
+        Real bare = std::exp(-0.02 * t);
+        return std::make_pair(yield.discount(t) / bare, credit.survivalProbability(t) / bare);
+    };
+
+    Handle<Quote> q(ext::make_shared<SimpleQuote>(0.99));
+
+    // a jump whose date is already in the past must be ignored
+    {
+        auto [y, c] = ratio({q}, {today - 30}, 1.0);
+        BOOST_CHECK_CLOSE(y, 1.0, tolerance);
+        BOOST_CHECK_CLOSE(c, y, tolerance);
+    }
+    // a jump on the reference date must be ignored
+    {
+        auto [y, c] = ratio({q}, {today}, 1.0);
+        BOOST_CHECK_CLOSE(y, 1.0, tolerance);
+        BOOST_CHECK_CLOSE(c, y, tolerance);
+    }
+    // unsorted jump dates: the jump before t applies, the one after does not
+    {
+        Handle<Quote> a(ext::make_shared<SimpleQuote>(0.90));
+        Handle<Quote> b(ext::make_shared<SimpleQuote>(0.95));
+        auto [y, c] = ratio({a, b}, {today + 5 * 365, today + 365}, 2.0);
+        BOOST_CHECK_CLOSE(y, 0.95, tolerance);
+        BOOST_CHECK_CLOSE(c, y, tolerance);
+    }
+    // a jump inside the interval still applies
+    {
+        auto [y, c] = ratio({q}, {today + 180}, 1.0);
+        BOOST_CHECK_CLOSE(y, 0.99, tolerance);
+        BOOST_CHECK_CLOSE(c, y, tolerance);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #2764.

`DefaultProbabilityTermStructure::survivalProbability` and `YieldTermStructure::discount` run structurally the same jump loop, but the credit one drifts in two places:

- no `jumpTimes_[i] > 0` guard, so a jump date that has rolled into the past (negative time) keeps getting multiplied into every result, and a jump exactly on the reference date is included where the yield side drops it;
- the `< t` test sits in the `for` header rather than the body, so an unsorted jump vector stops the loop at the first date past `t` instead of skipping it.

This changes the credit loop to match the yield one: iterate all jumps, apply `jumpTimes_[i] > 0 && jumpTimes_[i] < t` as a filter in the body.

I couldn't build the full test-suite here (local MinGW/boost setup is incomplete), so I checked the loop change in isolation against the yield-side reference:

```
case                            yield  creditOld  creditNew
expired jump (t<0)             1.0000     0.9900     1.0000  new==yield
jump on reference (t=0)        1.0000     0.9900     1.0000  new==yield
unsorted {5y,1y} at 2y         0.9500     1.0000     0.9500  new==yield
in-range jump                  0.9900     0.9900     0.9900  new==yield
sorted {1y,5y} at 2y           0.9500     0.9500     0.9500  new==yield
```

Added `testJumps` to `defaultprobabilitycurves.cpp` covering the three cases, using a flat-rate zero curve carrying the same jumps as the oracle.

The issue also asks whether an unsorted `jumpDates` should be rejected at construction. The yield side doesn't do that and the per-element filter handles it correctly, so I left it alone — can add a check if you'd rather have one.
