### PR TITLE
Fix `SmileSectionRNDCalculator` tail quantiles for smiles with fat wings

### DIFF
--- a/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.cpp
@@ -19,13 +19,51 @@
 
 #include <ql/errors.hpp>
 #include <ql/math/comparison.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp>
 #include <ql/termstructures/volatility/smilesection.hpp>
 #include <algorithm>
 #include <cmath>
 #include <utility>
+#include <vector>
 
 namespace QuantLib {
+
+    namespace {
+
+        /*! P(S > K) for a call, P(S <= K) for a put. Each tail is taken from
+            its own option type rather than as 1 - p, so the small number the
+            wings need is never the difference of two numbers close to one.
+
+            The gap scales with the strike, since the grid is walked outward
+            over decades and a width suiting the forward is far too coarse by
+            the wings. It stays well above the underflow floor that
+            digitalOptionPrice applies for itself.
+        */
+        Real tailProbability(const SmileSection& smile, Real strike, Option::Type type) {
+            const Real relativeGap = 2.0e-6;
+            const Real gap = std::max(std::abs(strike), QL_EPSILON) * relativeGap;
+            return std::clamp(smile.digitalOptionPrice(strike, type, 1.0, gap),
+                              Real(0.0), Real(1.0));
+        }
+
+        //! z = Phi^{-1}(P(S <= K)) at log-moneyness x, or Null<Real>() if unusable.
+        Real normalQuantileAt(const SmileSection& smile, Real forward, Real x) {
+            const InverseCumulativeNormal invPhi;
+            const Real strike = forward * std::exp(x);
+            if (!std::isfinite(strike) || strike <= 0.0)
+                return Null<Real>();
+
+            const Real p = (x <= 0.0) ? tailProbability(smile, strike, Option::Put)
+                                      : tailProbability(smile, strike, Option::Call);
+            if (p <= 0.0 || p >= 1.0)
+                return Null<Real>();
+
+            const Real z = (x <= 0.0) ? invPhi(p) : -invPhi(p);
+            return std::isfinite(z) ? z : Null<Real>();
+        }
+
+    }
 
     SmileSectionRNDCalculator::SmileSectionRNDCalculator(
         ext::shared_ptr<SmileSection> smile,
@@ -50,47 +88,140 @@ namespace QuantLib {
         if (initialized_)
             return;
 
-        const Real forward = smile_->atmLevel();
-        QL_REQUIRE(forward != Null<Real>(),
+        forward_ = smile_->atmLevel();
+        QL_REQUIRE(forward_ != Null<Real>(),
                    "SmileSectionRNDCalculator: smile->atmLevel() returned "
                    "Null<Real>(); wrap with AtmSmileSection to supply one");
 
         const Time T = smile_->exerciseTime();
-        const Real sigmaAtm = smile_->volatility(forward);
-        const Real logStd = sigmaAtm * std::sqrt(T);
-        const Real kMin = std::max(forward * std::exp(-nStd_ * logStd), QL_EPSILON);
-        const Real kMax = forward * std::exp( nStd_ * logStd);
+        const Real logStd = smile_->volatility(forward_) * std::sqrt(T);
+        QL_REQUIRE(logStd > 0.0,
+                   "SmileSectionRNDCalculator: non-positive at-the-money "
+                   "volatility " << logStd);
 
-        // Build a strictly-increasing (cdf, strike) grid via 
-        // Breeden-Litzenberger:  CDF(K) = 1 - C'(K).
-        // The undiscounted digital call (discount=1) gives the risk-neutral
-        // probability P(S > K). BL output may be slightly non-monotone
-        // near the wings, so we take a running max and drop
-        // near-duplicates to give the spline a strict abscissa.
-        strikes_.clear();
-        cdf_.clear();
-        strikes_.reserve(nStrikes_);
-        cdf_.reserve(nStrikes_);
-        constexpr double dedupTol = 1e-12;
-        Real lastCdf = -1.0;
-        for (Size i = 0; i < nStrikes_; ++i) {
-            const Real K = kMin + (kMax - kMin) * i / (nStrikes_ - 1);
-            const Real c = std::clamp(
-                Real(1.0 - smile_->digitalOptionPrice(K, Option::Call, 1.0)),
-                Real(0.0), Real(1.0));
-            const Real cMono = std::max(c, lastCdf);
-            if (cMono - lastCdf > dedupTol) {
-                strikes_.push_back(K);
-                cdf_.push_back(cMono);
-                lastCdf = cMono;
+        // Fat wings reach a given quantile much further out in strike than a
+        // lognormal does, so the extent has to be found rather than assumed.
+        const Real zAtm = normalQuantileAt(*smile_, forward_, 0.0);
+        QL_REQUIRE(zAtm != Null<Real>(),
+                   "SmileSectionRNDCalculator: could not determine the "
+                   "quantile at the forward");
+
+        // Doubled while out of reach, since a step tuned to a low ATM vol
+        // cannot cross fat wings.
+        const Real firstStep = 0.5 * logStd;
+        // Ample for doubling out and backing off again.
+        constexpr Size maxSteps = 200;
+        // Finer than the tabulated map can resolve.
+        const Real xTol = 1e-12;
+
+        const auto edge = [&](Real target) {
+            Real x = 0.0;
+            Real step = firstStep;
+            const Real direction = target > zAtm ? 1.0 : -1.0;
+            for (Size i = 0; i < maxSteps; ++i) {
+                const Real trial = x + direction * step;
+                const Real trialZ = normalQuantileAt(*smile_, forward_, trial);
+                if (trialZ == Null<Real>()) {
+                    // Overshot past where the smile still prices, so back off.
+                    step *= 0.5;
+                    if (step < xTol)
+                        break;
+                    continue;
+                }
+
+                const bool bracketed =
+                    direction > 0.0 ? trialZ >= target : trialZ <= target;
+                if (bracketed) {
+                    // z increases with x, so this brackets either way.
+                    Real xLo = std::min(x, trial);
+                    Real xHi = std::max(x, trial);
+                    while (xHi - xLo > xTol) {
+                        const Real xMid = 0.5 * (xLo + xHi);
+                        if (xMid <= xLo || xMid >= xHi)
+                            break; // down to one representable step
+                        const Real zMid =
+                            normalQuantileAt(*smile_, forward_, xMid);
+                        QL_REQUIRE(zMid != Null<Real>(),
+                                   "SmileSectionRNDCalculator: could not "
+                                   "refine a tail quantile");
+                        if (zMid < target)
+                            xLo = xMid;
+                        else
+                            xHi = xMid;
+                    }
+                    return 0.5 * (xLo + xHi);
+                }
+
+                x = trial;
+                step *= 2.0;
             }
-        }
-        QL_REQUIRE(cdf_.size() >= 4,
-                   "SmileSectionRNDCalculator: too few unique CDF points ("
-                   << cdf_.size() << ") after deduplication");
+            return x;
+        };
+
+        const Real xMax = edge(nStd_);
+        const Real xMin = edge(-nStd_);
+        QL_REQUIRE(xMax > xMin,
+                   "SmileSectionRNDCalculator: could not bracket the quantile range; "
+                   "the smile returns no usable tail probability");
+
+        const auto linspace = [](Real lo, Real hi, Size n) {
+            std::vector<Real> v(n);
+            for (Size i = 0; i < n; ++i)
+                v[i] = lo + (hi - lo) * i / (n - 1);
+            return v;
+        };
+
+        // Sample the map, keeping it strictly increasing so the spline gets a
+        // valid abscissa.
+        const auto sample = [&](const std::vector<Real>& xs,
+                                std::vector<Real>& zOut,
+                                std::vector<Real>& xOut) {
+            constexpr double dedupTol = 1e-12;
+            zOut.clear();
+            xOut.clear();
+            zOut.reserve(xs.size());
+            xOut.reserve(xs.size());
+            Real lastZ = -QL_MAX_REAL;
+            for (Real x : xs) {
+                const Real z = normalQuantileAt(*smile_, forward_, x);
+                if (z == Null<Real>())
+                    continue;
+                if (z > lastZ + dedupTol) {
+                    zOut.push_back(z);
+                    xOut.push_back(x);
+                    lastZ = z;
+                }
+            }
+        };
+
+        // Whatever consumes this samples in z, not in strike, so a grid uniform
+        // in log-moneyness puts its nodes in the wrong place once the smile has
+        // wings. Locate the map coarsely, then re-place the nodes uniformly in z.
+        // The locating pass only resolves the shape, not the node placement.
+        constexpr Size maxCoarseNodes = 100;
+        const Size nCoarse = std::min(maxCoarseNodes, nStrikes_);
+        std::vector<Real> zCoarse, xCoarse;
+        sample(linspace(xMin, xMax, nCoarse), zCoarse, xCoarse);
+        QL_REQUIRE(zCoarse.size() >= 4,
+                   "SmileSectionRNDCalculator: too few usable quantile points ("
+                   << zCoarse.size() << ") in the locating pass");
+
+        const MonotonicCubicNaturalSpline coarse(
+            zCoarse.begin(), zCoarse.end(), xCoarse.begin());
+        std::vector<Real> targets =
+            linspace(zCoarse.front(), zCoarse.back(), nStrikes_);
+        for (Real& t : targets)
+            t = coarse(t);
+
+        sample(targets, z_, logMoneyness_);
+        QL_REQUIRE(z_.size() >= 4,
+                   "SmileSectionRNDCalculator: too few usable quantile points ("
+                   << z_.size() << ") after deduplication");
 
         quantileFn_ = ext::make_shared<MonotonicCubicNaturalSpline>(
-            cdf_.begin(), cdf_.end(), strikes_.begin());
+            z_.begin(), z_.end(), logMoneyness_.begin());
+        zMin_ = z_.front();
+        zMax_ = z_.back();
 
         initialized_ = true;
     }
@@ -98,13 +229,20 @@ namespace QuantLib {
     Real SmileSectionRNDCalculator::pdf(Real x, Time t) const {
         checkTime(t);
         const Real S = std::exp(x);
+        // density() floors its own gap relative to the strike, which is what
+        // this needs walking out over decades, so the default is already right.
         return S * smile_->density(S, 1.0);
     }
 
     Real SmileSectionRNDCalculator::cdf(Real x, Time t) const {
         checkTime(t);
-        const Real S = std::exp(x);
-        return 1.0 - smile_->digitalOptionPrice(S, Option::Call, 1.0);
+        // Take each tail from its own option type, as the quantile grid does.
+        // atmLevel() may be absent, and cdf() does not otherwise need it.
+        const Real K = std::exp(x);
+        const Real atm = smile_->atmLevel();
+        if (atm != Null<Real>() && K <= atm)
+            return tailProbability(*smile_, K, Option::Put);
+        return 1.0 - tailProbability(*smile_, K, Option::Call);
     }
 
     Real SmileSectionRNDCalculator::invcdf(Real p, Time t) const {
@@ -112,9 +250,9 @@ namespace QuantLib {
         initialize();
         QL_REQUIRE(p > 0.0 && p < 1.0,
                    "p must be in (0, 1), got " << p);
-        const Real pClamped = std::min(std::max(p, cdf_.front()), cdf_.back());
-        const Real K = (*quantileFn_)(pClamped);
-        return std::log(K);
+        const InverseCumulativeNormal invPhi;
+        const Real z = std::clamp(invPhi(p), zMin_, zMax_);
+        return std::log(forward_) + (*quantileFn_)(z);
     }
 
     Real SmileSectionRNDCalculator::pdf(Real x) const {

--- a/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp
+++ b/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp
@@ -34,12 +34,19 @@ namespace QuantLib {
 
     class SmileSection;
 
+    /*! Tabulates log-moneyness against the normal quantile
+        \f$ z = \Phi^{-1}(P(S \leq K)) \f$, which is linear for a lognormal law
+        and stays well conditioned in the wings.
+
+        \param nStd half-width of the tabulated range in normal quantiles, or
+                    the deepest the smile still prices. invcdf saturates there.
+    */
     class SmileSectionRNDCalculator : public RiskNeutralDensityCalculator {
       public:
         explicit SmileSectionRNDCalculator(
             ext::shared_ptr<SmileSection> smile,
             Size nStrikes = 200,
-            Real nStd = 5.0);
+            Real nStd = 8.0);
 
         // x = ln(S)
         Real pdf(Real x, Time t) const override;
@@ -60,7 +67,8 @@ namespace QuantLib {
         Real nStd_;
 
         mutable bool initialized_ = false;
-        mutable std::vector<Real> strikes_, cdf_;
+        mutable Real forward_ = 0.0, zMin_ = 0.0, zMax_ = 0.0;
+        mutable std::vector<Real> z_, logMoneyness_;
         mutable ext::shared_ptr<MonotonicCubicNaturalSpline> quantileFn_;
     };
 

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -2869,6 +2869,81 @@ BOOST_AUTO_TEST_CASE(testGaussianCopulaSpreadEngineSVI) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testGaussianCopulaSpreadEngineParityAcrossVols) {
+    BOOST_TEST_MESSAGE("Testing Gaussian Copula spread engine put-call parity "
+                       "across volatility levels...");
+
+    // Parity only needs each marginal to price its own forward. A smile with fat
+    // wings is where that marginal construction is actually stressed.
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(1, March, 2025);
+    const Date maturity = today + Period(12, Months);
+    const Time T = dc.yearFraction(today, maturity);
+
+    const ext::shared_ptr<EuropeanExercise> exercise
+        = ext::make_shared<EuropeanExercise>(maturity);
+
+    const Real rho = 0.5, strike = 20.0;
+    const Real f1 = 50.0, f2 = 30.0;
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.0, dc));
+
+    constexpr double parityRelTol = 1e-4;
+
+    for (Real c : { 0.7, 1.0, 1.5, 2.0 }) {
+        const std::vector<Real> svi1 = { c * c * 0.1125, c * c * 0.10,
+                                         0.10, 0.525, 0.0 };
+        const std::vector<Real> svi2 = { c * c * 0.08, c * c * 0.10,
+                                         0.10, 0.18, 0.0 };
+
+        const auto smile1 = ext::make_shared<SviSmileSection>(T, f1, svi1);
+        const auto smile2 = ext::make_shared<SviSmileSection>(T, f2, svi2);
+
+        const Handle<BlackVolTermStructure> volTS1(
+            ext::make_shared<PiecewiseBlackVarianceSurface>(
+                today, maturity, smile1, dc));
+        const Handle<BlackVolTermStructure> volTS2(
+            ext::make_shared<PiecewiseBlackVarianceSurface>(
+                today, maturity, smile2, dc));
+
+        const ext::shared_ptr<BlackProcess> p1 =
+            ext::make_shared<BlackProcess>(
+                Handle<Quote>(ext::make_shared<SimpleQuote>(f1)), rTS, volTS1);
+        const ext::shared_ptr<BlackProcess> p2 =
+            ext::make_shared<BlackProcess>(
+                Handle<Quote>(ext::make_shared<SimpleQuote>(f2)), rTS, volTS2);
+
+        const ext::shared_ptr<PricingEngine> engine
+            = ext::make_shared<GaussianCopulaSpreadEngine>(p1, p2, rho);
+
+        BasketOption callOption(ext::make_shared<SpreadBasketPayoff>(
+                ext::make_shared<PlainVanillaPayoff>(Option::Call, strike)),
+            exercise);
+        callOption.setPricingEngine(engine);
+
+        BasketOption putOption(ext::make_shared<SpreadBasketPayoff>(
+                ext::make_shared<PlainVanillaPayoff>(Option::Put, strike)),
+            exercise);
+        putOption.setPricingEngine(engine);
+
+        const Real fwd = (callOption.NPV() - putOption.NPV())
+            / rTS->discount(maturity);
+        const Real expectedFwd = f1 - f2 - strike;
+        const Real relError = std::fabs(fwd - expectedFwd) / f1;
+
+        if (relError > parityRelTol) {
+            BOOST_FAIL("failed to reproduce call-put parity using the "
+                       "Gaussian Copula spread engine with an SVI smile."
+                       << std::fixed << std::setprecision(8)
+                       << "\n    vol scale     : " << c
+                       << "\n    atm vol leg 1 : " << smile1->volatility(f1)
+                       << "\n    calculated fwd: " << fwd
+                       << "\n    expected fwd  : " << expectedFwd
+                       << "\n    rel error     : " << relError
+                       << "\n    tolerance     : " << parityRelTol);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -21,8 +21,10 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include <ql/experimental/volatility/svismilesection.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/methods/finitedifferences/utilities/bsmrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/cevrndcalculator.hpp>
@@ -856,6 +858,75 @@ BOOST_AUTO_TEST_CASE(testSmileSectionRNDvsBSM) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDQuantileRange) {
+    BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator quantile-range "
+                       "saturation...");
+
+    const Time T = 1.0;
+    const Real fwd = 100.0;
+    const Volatility vol = 0.20;
+    const Real nStd = 1.0;
+    const auto smile = ext::make_shared<FlatSmileSection>(
+        T, vol, DayCounter(), fwd);
+    const SmileSectionRNDCalculator rnd(smile, 200, nStd);
+    const CumulativeNormalDistribution Phi;
+
+    const Real logMean = std::log(fwd) - 0.5 * vol * vol * T;
+    const Real tol = 1e-6;
+    for (Real sign : { -1.0, 1.0 }) {
+        const Real probability = Phi(sign * 2.0 * nStd);
+        const Real calculated = rnd.invcdf(probability);
+        const Real expected = logMean + sign * nStd * vol * std::sqrt(T);
+
+        if (std::fabs(calculated - expected) > tol) {
+            BOOST_FAIL("failed to saturate at the requested normal quantile"
+                       << "\n   side:       " << sign
+                       << "\n   calculated: " << calculated
+                       << "\n   expected:   " << expected
+                       << "\n   difference: " << calculated - expected
+                       << "\n   tolerance:  " << tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDLowVolFatWings) {
+    BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator quantile range at a "
+                       "low at-the-money volatility...");
+
+    // Wings reaching far in log-moneyness on a 5% ATM volatility, which a
+    // search stepping in ATM standard deviations cannot cross.
+    const std::vector<Real> svi = { -0.7124561725, 0.2210528950, 3.2365013812,
+                                    -0.0171352352, -0.0547257886 };
+    const Real fwd = 50.0;
+    const Real nStd = 8.0;
+
+    const auto smile = ext::make_shared<SviSmileSection>(1.0, fwd, svi);
+    const SmileSectionRNDCalculator rnd(smile, 200, nStd);
+    const CumulativeNormalDistribution Phi;
+    const InverseCumulativeNormal invPhi;
+
+    const Real tol = 1e-3;
+    const Real edge = rnd.invcdf(Phi(-nStd));
+    const Real reached = invPhi(rnd.cdf(edge));
+
+    if (std::fabs(reached + nStd) > tol) {
+        BOOST_FAIL("failed to reach the requested quantile"
+                   << "\n   requested: " << -nStd
+                   << "\n   reached:   " << reached
+                   << "\n   at x:      " << edge
+                   << "\n   tolerance: " << tol);
+    }
+
+    // Beyond the range the quantile saturates.
+    const Real beyond = rnd.invcdf(Phi(-nStd - 1.0));
+    if (std::fabs(beyond - edge) > tol) {
+        BOOST_FAIL("failed to saturate past the tabulated range"
+                   << "\n   at the edge: " << edge
+                   << "\n   beyond it:   " << beyond
+                   << "\n   tolerance:   " << tol);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testSmileSectionRNDvsHeston) {
     BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator on a Heston-implied "
                        "smile against HestonRNDCalculator...");
@@ -934,6 +1005,129 @@ BOOST_AUTO_TEST_CASE(testSmileSectionRNDMissingAtmLevel) {
     BOOST_CHECK_EXCEPTION(
         rnd.invcdf(0.5, T), QuantLib::Error,
         ExpectedErrorMessage("AtmSmileSection"));
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDMartingale) {
+    BOOST_TEST_MESSAGE("Testing that SmileSectionRNDCalculator reproduces the "
+                       "forward across volatility levels...");
+
+    // Scaling SVI total variance by c^2 fattens the wings while holding their
+    // shape. The tail then carries a share of E[S] far out of proportion to its
+    // probability, which is what a coarse or truncated quantile grid loses.
+    const Date today = Settings::instance().evaluationDate();
+    const Date maturity = today + 1 * Years;
+    const Time T = Actual365Fixed().yearFraction(today, maturity);
+    const Real fwd = 50.0;
+    // The residual is the tabulated quantile range, not the grid: refining the
+    // grid stalls at this level because invcdf takes a probability, which pins
+    // the deepest reachable quantile near 8 standard deviations.
+    const Real tol = 5.0e-3;
+
+    GaussHermiteIntegration gh(64);
+    const Array& nodes = gh.x();
+    const Array& weights = gh.weights();
+    const CumulativeNormalDistribution Phi;
+
+    for (Real c : { 0.7, 1.0, 1.5, 2.0, 2.5 }) {
+        const std::vector<Real> svi = { c * c * 0.1125, c * c * 0.10,
+                                        0.10, 0.525, 0.0 };
+        const auto smile = ext::make_shared<SviSmileSection>(T, fwd, svi);
+        const SmileSectionRNDCalculator rnd(smile);
+
+        Real mean = 0.0;
+        for (Size i = 0; i < gh.order(); ++i) {
+            const Real x = nodes[i];
+            const Real u = std::clamp(Phi(M_SQRT2 * x),
+                                      Real(QL_EPSILON), Real(1.0 - QL_EPSILON));
+            mean += weights[i] * std::exp(-x * x) * std::exp(rnd.invcdf(u));
+        }
+        mean /= std::sqrt(M_PI);
+
+        const Real relError = std::fabs(mean - fwd) / fwd;
+        if (relError > tol) {
+            BOOST_FAIL("failed to reproduce the forward from the "
+                       "SmileSectionRNDCalculator quantile"
+                       << std::fixed << std::setprecision(8)
+                       << "\n   vol scale : " << c
+                       << "\n   atm vol   : " << smile->volatility(fwd)
+                       << "\n   E[S]      : " << mean
+                       << "\n   forward   : " << fwd
+                       << "\n   rel error : " << relError
+                       << "\n   tolerance : " << tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDLeftTailCdf) {
+    BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator cdf deep in the "
+                       "left tail...");
+
+    // Below the forward the cdf is the small number, so taking it as
+    // 1 - P(S > K) spends it against a value close to one: at four standard
+    // deviations that left ~3 correct bits, and by six it returned zero. The
+    // put digital carries the same probability directly.
+    const Date today = Settings::instance().evaluationDate();
+    const Date maturity = today + 1 * Years;
+    const Time T = Actual365Fixed().yearFraction(today, maturity);
+    const Real fwd = 50.0;
+    const std::vector<Real> svi = { 0.1125, 0.10, 0.10, 0.525, 0.0 };
+
+    // A flat smile has an analytic left tail, so the reference here is
+    // independent of how the calculator obtains it.
+    const Volatility flatVol = 0.20;
+    const Real stdDev = flatVol * std::sqrt(T);
+    const auto flat = ext::make_shared<FlatSmileSection>(
+        T, flatVol, DayCounter(), fwd);
+    const SmileSectionRNDCalculator flatRnd(flat);
+    const CumulativeNormalDistribution Phi;
+
+    // Difference-quotient error grows as the probability shrinks, to a
+    // measured 1.4e-5 at the deepest point below.
+    const Real flatTol = 1e-4;
+    for (Real nStdDev : { 2.0, 3.0, 4.0, 5.0, 6.0 }) {
+        const Real x = std::log(fwd) - nStdDev * stdDev;
+        const Real d2 =
+            (std::log(fwd) - x) / stdDev - 0.5 * stdDev;
+
+        const Real calculated = flatRnd.cdf(x, T);
+        const Real expected = Phi(-d2);
+
+        BOOST_REQUIRE(value(expected) > 0.0);
+        const Real relError = std::fabs(calculated - expected) / expected;
+        if (relError > flatTol) {
+            BOOST_FAIL("failed to reproduce the analytic left-tail cdf"
+                       << "\n   std deviations: " << nStdDev
+                       << "\n   calculated:     " << calculated
+                       << "\n   expected:       " << expected
+                       << "\n   rel error:      " << relError
+                       << "\n   tolerance:      " << flatTol);
+        }
+    }
+
+    const auto smile = ext::make_shared<SviSmileSection>(T, fwd, svi);
+    const SmileSectionRNDCalculator rnd(smile);
+
+    const Real tol = 1e-6;
+    for (Real offset : { -2.0, -3.0, -4.0, -5.0, -6.0 }) {
+        const Real x = std::log(fwd) + offset;
+        const Real K = std::exp(x);
+
+        const Real calculated = rnd.cdf(x, T);
+        const Real expected = smile->digitalOptionPrice(
+            K, Option::Put, 1.0, std::abs(K) * 2.0e-6);
+
+        BOOST_REQUIRE(value(expected) > 0.0);
+        const Real relError = std::fabs(calculated - expected) / expected;
+        if (relError > tol) {
+            BOOST_FAIL("failed to reproduce the left-tail cdf"
+                       << "\n   log-moneyness: " << offset
+                       << "\n   strike:        " << K
+                       << "\n   calculated:    " << calculated
+                       << "\n   expected:      " << expected
+                       << "\n   rel error:     " << relError
+                       << "\n   tolerance:     " << tol);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up to #2768.

With fat wings, the fixed ±5 ATM-standard-deviation strike grid can make
`invcdf` saturate too early. Computing the left-tail CDF as `1 - P(S > K)`
also loses precision.

This tabulates log-moneyness against $z = \Phi^{-1}(P(S \leq K))$, with nodes
approximately uniform in `z` and an adaptive search for the range endpoints.
Each tail uses its own put or call digital, with a relative gap of `|K| * 2e-6`
to limit roundoff across widely varying strikes.

The `nStd` default changes from 5 to 8. This also changes
`GaussianCopulaSpreadEngine` prices, since it uses the calculator's defaults.

Five regression tests cover forward reproduction, quantile saturation,
low-ATM-volatility fat wings, spread put-call parity, and the left-tail CDF
against the analytic lognormal result.