### PR TITLE
Fix duplicated words in documentation comments

### DIFF
--- a/ql/cashflows/digitalcmscoupon.hpp
+++ b/ql/cashflows/digitalcmscoupon.hpp
@@ -32,7 +32,7 @@
 
 namespace QuantLib {
 
-    //! Cms-rate coupon with digital digital call/put option
+    //! Cms-rate coupon with digital call/put option
     class DigitalCmsCoupon : public DigitalCoupon {
       public:
         DigitalCmsCoupon(

--- a/ql/cashflows/digitalcoupon.hpp
+++ b/ql/cashflows/digitalcoupon.hpp
@@ -148,9 +148,9 @@ namespace QuantLib {
         //@{
         //!
         ext::shared_ptr<FloatingRateCoupon> underlying_;
-        //! strike rate for the the call option
+        //! strike rate for the call option
         Rate callStrike_;
-        //! strike rate for the the put option
+        //! strike rate for the put option
         Rate putStrike_;
         //! multiplicative factor of call payoff
         Real callCsi_ = 0.;

--- a/ql/cashflows/digitaliborcoupon.hpp
+++ b/ql/cashflows/digitaliborcoupon.hpp
@@ -32,7 +32,7 @@
 
 namespace QuantLib {
 
-    //! Ibor rate coupon with digital digital call/put option
+    //! Ibor rate coupon with digital call/put option
     class DigitalIborCoupon : public DigitalCoupon {
       public:
         DigitalIborCoupon(

--- a/ql/experimental/coupons/digitalcmsspreadcoupon.hpp
+++ b/ql/experimental/coupons/digitalcmsspreadcoupon.hpp
@@ -30,7 +30,7 @@
 
 namespace QuantLib {
 
-    //! Cms-spread-rate coupon with digital digital call/put option
+    //! Cms-spread-rate coupon with digital call/put option
     class DigitalCmsSpreadCoupon : public DigitalCoupon {
       public:
         explicit DigitalCmsSpreadCoupon(

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -493,7 +493,7 @@ namespace QuantLib {
                 atmYoYSwapDateRates_.first.push_back(referenceDate()+cfMaturities_[i]);
                 atmYoYSwapTimeRates_.first.push_back(timeFromReference(referenceDate()+cfMaturities_[i]));
                 // atmYoYSwapRates_->second.push_back(interpol((*cfMaturities_)[i]));
-                // Heuristic: overwrite the the swap rate with a value that guarantees that the
+                // Heuristic: overwrite the swap rate with a value that guarantees that the
                 // intrinsic value of all options is lower than the price
                 Real newSwapRate = minSwapRateIntersection[i] + intrinsicValueAddOn;
                 if (newSwapRate > maxSwapRateIntersection[i])

--- a/ql/models/marketmodels/models/alphafinder.cpp
+++ b/ql/models/marketmodels/models/alphafinder.cpp
@@ -354,7 +354,7 @@ Real AlphaFinder::computeLinearPart(Real alpha) {
         Real bilimit = alpha0;
 
         if (bottomValue > targetVariance && topValue > targetVariance) {
-            // see if if ok at some intermediate point by stepping through
+            // see if ok at some intermediate point by stepping through
             Integer i=1;
             while ( i < steps && topValue> targetVariance) {
                 topAlpha = alpha0 + (alphaMax-alpha0)*(i+0.0)/(steps+0.0);
@@ -367,7 +367,7 @@ Real AlphaFinder::computeLinearPart(Real alpha) {
         }
 
         if (bottomValue > targetVariance && topValue > targetVariance) {
-            // see if if ok at some intermediate point by stepping through
+            // see if ok at some intermediate point by stepping through
             Integer i=1;
             while ( i < steps && topValue> targetVariance) {
                 bottomAlpha = alpha0 + (alphaMin-alpha0)*(i+0.0)/(steps+0.0);


### PR DESCRIPTION
## Rationale for this change

Several comments contain accidentally doubled words — `strike rate for the the call option`, `with digital digital call/put option`, `see if if ok`. Six of the eight are Doxygen `//!` comments on public classes and data members, so they render in the generated reference documentation.

These survive automated checking. The `misspell-fixer` workflow runs on every push and auto-opens correction PRs (e.g. #796), but it matches misspelled *words*; a correctly spelled word repeated twice is not a misspelling, so it cannot detect these. Running `misspell-fixer` locally over the six files below reports nothing, while a control file containing `recieve` and `seperate` is flagged immediately.

Found by searching the tree for `\b(\w+)\s+\1\b` restricted to comment lines.

## What changes are included in this PR?

Removes 8 doubled words across 6 files. Comment text only — no code changes.

| File | Fix |
| --- | --- |
| `ql/cashflows/digitalcoupon.hpp` (x2) | `strike rate for the the call option` / `for the the put option`, on the `callStrike_` and `putStrike_` members |
| `ql/cashflows/digitaliborcoupon.hpp` | `Ibor rate coupon with digital digital call/put option` |
| `ql/cashflows/digitalcmscoupon.hpp` | `Cms-rate coupon with digital digital call/put option` |
| `ql/experimental/coupons/digitalcmsspreadcoupon.hpp` | `Cms-spread-rate coupon with digital digital call/put option` |
| `ql/experimental/inflation/yoycapfloortermpricesurface.hpp` | `Heuristic: overwrite the the swap rate` |
| `ql/models/marketmodels/models/alphafinder.cpp` (x2) | `see if if ok at some intermediate point` |

Deliberately left alone, as these are not typos:

- `float float swap` in `ql/instruments/floatfloatswap.hpp` and `ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.hpp` — this names the `FloatFloatSwap` instrument.
- `barrier     barrier type` in `test-suite/barrieroption.cpp` — column headings in a data table.
- `rank inf/inf 5/inf inf/5 5/5` in `test-suite/nthtodefault.cpp`.

## Testing

No new tests. The change is confined to comments, so there is no behaviour to cover.

Checks run locally on Linux x86_64, g++ 13.3.0, Boost 1.83, C++17:

- `./tools/check_all_header_docs.sh` (the `header-docs` job in `.github/workflows/doxygen.yml`) — pass
- Syntax-only compile of a translation unit including all five changed headers, `g++ -std=c++17 -fsyntax-only` against a CMake-generated `ql/config.hpp` — pass
- Full compile of the one changed source file, `g++ -std=c++17 -c -O2 -Wall ql/models/marketmodels/models/alphafinder.cpp` — pass, no warnings

I could **not** run `make docs`. It fails on my machine with `Docs/quantlibheader.html: error: Remaining begin replacement with marker 'HTML_DYNAMIC_SECTIONS'`, and it fails **identically on an unmodified checkout of master**, so this is a local Doxygen version mismatch (1.9.8 from Ubuntu, against the newer Homebrew Doxygen the macOS CI job uses) and not an effect of this PR. The Doxygen job on this PR will be the first real run of that check.

I also did not run the full test-suite; no changed line is code.

---

## AI disclosure

This contribution was AI-assisted. Claude Code (Claude Opus 5) performed the tree-wide doubled-word search, made the 8 line edits, and ran the checks listed above. The check commands were executed by the AI and have not been independently re-run by hand.
