### PR TITLE
Fix data race in LazyObject::calculate() under thread-safe observer pattern

### DIFF
--- a/ql/patterns/lazyobject.hpp
+++ b/ql/patterns/lazyobject.hpp
@@ -27,6 +27,10 @@
 #include <ql/patterns/observable.hpp>
 #include <ql/shared_ptr.hpp>
 
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+#include <mutex>
+#endif
+
 namespace QuantLib {
 
     //! Framework for calculation on demand and result caching.
@@ -131,6 +135,31 @@ namespace QuantLib {
         mutable bool calculated_ = false, frozen_ = false, failed_ = false, alwaysForward_;
       private:
         bool updating_ = false;
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        /*! Guards calculated_/frozen_/failed_/updating_/alwaysForward_
+            so that calculate() (and the other methods touching this
+            object's calculation state) are safe to call concurrently
+            from multiple threads, as promised by
+            QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN.
+
+            Wrapped so that LazyObject keeps its existing implicit
+            copy/move semantics: copying or moving a LazyObject gives
+            the copy a fresh, unlocked mutex rather than trying to
+            copy the mutex itself.
+        */
+        class RecursiveMutex {
+          public:
+            RecursiveMutex() = default;
+            RecursiveMutex(const RecursiveMutex&) noexcept {}
+            RecursiveMutex(RecursiveMutex&&) noexcept {}
+            RecursiveMutex& operator=(const RecursiveMutex&) noexcept { return *this; }
+            RecursiveMutex& operator=(RecursiveMutex&&) noexcept { return *this; }
+            std::recursive_mutex& get() const { return mutex_; }
+          private:
+            mutable std::recursive_mutex mutex_;
+        };
+        mutable RecursiveMutex mutex_;
+        #endif
         class UpdateChecker {  // NOLINT(cppcoreguidelines-special-member-functions)
             LazyObject* subject_;
           public:
@@ -188,6 +217,9 @@ namespace QuantLib {
     : alwaysForward_(LazyObject::Defaults::instance().forwardsAllNotifications()) {}
 
     inline void LazyObject::update() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         if (updating_) {
             #ifdef QL_THROW_IN_CYCLES
             QL_FAIL("recursive notification loop detected; you probably created an object cycle");
@@ -219,6 +251,9 @@ namespace QuantLib {
     }
 
     inline void LazyObject::recalculate() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         bool wasFrozen = frozen_;
         calculated_ = frozen_ = failed_ = false;
         try {
@@ -233,10 +268,16 @@ namespace QuantLib {
     }
 
     inline void LazyObject::freeze() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         frozen_ = true;
     }
 
     inline void LazyObject::unfreeze() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         // send notifications, just in case we lost any,
         // but only once, i.e. if it was frozen
         if (frozen_) {
@@ -246,14 +287,23 @@ namespace QuantLib {
     }
 
     inline void LazyObject::forwardFirstNotificationOnly() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         alwaysForward_ = false;
     }
 
     inline void LazyObject::alwaysForwardNotifications() {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         alwaysForward_ = true;
     }
 
     inline void LazyObject::calculate() const {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         if (!calculated_ && !frozen_) {
             calculated_ = true;   // prevent infinite recursion in
                                   // case of bootstrapping
@@ -270,10 +320,16 @@ namespace QuantLib {
     }
 
     inline bool LazyObject::isCalculated() const {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         return calculated_;
     }
 
     inline void LazyObject::setCalculated(const bool c) const {
+        #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(mutex_.get());
+        #endif
         calculated_ = c;
     }
 }

--- a/test-suite/lazyobject.cpp
+++ b/test-suite/lazyobject.cpp
@@ -22,6 +22,12 @@
 #include <ql/instruments/stock.hpp>
 #include <ql/quotes/simplequote.hpp>
 
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+#include <atomic>
+#include <thread>
+#include <vector>
+#endif
+
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 using ext::shared_ptr;
@@ -271,6 +277,52 @@ BOOST_AUTO_TEST_CASE(testNotificationAfterFailedCalculation) {
     if (f.isUp())
         BOOST_FAIL("Observer was notified of second change without recalculation");
 }
+
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+
+BOOST_AUTO_TEST_CASE(testConcurrentCalculate) {
+
+    BOOST_TEST_MESSAGE("Testing concurrent calls to LazyObject::calculate()...");
+
+    // calculate() reads and writes calculated_/frozen_/failed_ (and,
+    // via the UpdateChecker used by update(), updating_) without any
+    // synchronization of its own. QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+    // only makes Observable/Observer registration thread-safe; it does
+    // not protect LazyObject's own calculation state. So calling
+    // calculate() concurrently on the same object is a data race
+    // (reported by ThreadSanitizer) and can, in principle, let
+    // performCalculations() run more than once for what should be a
+    // single calculation. See
+    // https://github.com/lballabio/QuantLib/issues/2633
+    class Counter : public LazyObject {
+      public:
+        void doCalculate() const { calculate(); }
+        mutable std::atomic<int> computations{0};
+
+      protected:
+        void performCalculations() const override { ++computations; }
+    };
+
+    for (Size trial = 0; trial < 500; ++trial) {
+        auto obj = ext::make_shared<Counter>();
+
+        std::vector<std::thread> threads;
+        threads.reserve(8);
+        for (Size t = 0; t < 8; ++t)
+            threads.emplace_back([obj]() { obj->doCalculate(); });
+        for (auto& thread : threads)
+            thread.join();
+
+        if (!obj->isCalculated())
+            BOOST_FAIL("object should be calculated after "
+                       "concurrent calculate() calls");
+        if (obj->computations != 1)
+            BOOST_FAIL("performCalculations() should have run exactly once, "
+                       "but ran " << obj->computations << " times");
+    }
+}
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
## Summary

Fixes #2633.

`QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN` makes `Observable`/`Observer` registration thread-safe (via a `recursive_mutex` guarding their internal sets in `observable.hpp`/`.cpp`), but `LazyObject::calculate()` itself reads and writes `calculated_`/`frozen_`/`failed_`/`updating_` with no synchronization of its own. So calling `calculate()` concurrently on the same `LazyObject` is a data race, even with the macro enabled -- the macro name is a bit misleading, since it does not make `LazyObject` itself safe to use from multiple threads.

Confirmed with ThreadSanitizer: a minimal repro (8 threads calling `calculate()` concurrently on one `LazyObject`, 500 iterations) reproduces the race 10/10 runs, always at the `calculated_` check-and-set in `calculate()`.

## Fix

Guard `calculate()` and the other methods touching this state (`update()`, `recalculate()`, `freeze()`, `unfreeze()`, `forwardFirstNotificationOnly()`, `alwaysForwardNotifications()`, `isCalculated()`, `setCalculated()`) with a `recursive_mutex`, following the same locking pattern already used by `Observer` in this codebase. The mutex is wrapped in a small helper so `LazyObject` keeps its existing implicit copy/move semantics (a raw `std::recursive_mutex` member would otherwise silently delete them). The whole change is compiled out when `QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN` is off, so there is no cost or behavior change for the default configuration.

## Testing

- New regression test `testConcurrentCalculate` in `test-suite/lazyobject.cpp`, guarded by the same macro (matching the existing convention in `test-suite/observable.cpp`). Verified with real CI-style TSan settings (`TSAN_OPTIONS=halt_on_error=1 exitcode=66`): fails deterministically (exit 66) before this fix, 5/5 runs; passes cleanly (exit 0) after, 5/5 runs.
- Full library + entire test suite built and run with `QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN=ON` (Debug, GCC 13.3.0): all tests pass, no regressions.
- Verified the fix and test also compile cleanly with the macro off (default config), confirming zero impact there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
