### PR TITLE
Avoid test-setup antipatterns that are no longer needed

### DIFF
--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -343,8 +343,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
         202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
         207.3};
 
-    RelinkableHandle<ZeroInflationTermStructure> hz;
-    auto ii = ext::make_shared<UKRPI>(hz);
+    auto ii = ext::make_shared<UKRPI>();
     for (Size i=0; i<std::size(fixData); i++) {
         ii->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -390,7 +389,6 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS =
         ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
             evaluationDate, baseDate, frequency, dc, helpers);
-    hz.linkTo(pZITS);
 
     //===========================================================================================
     // first check that the quoted swaps are repriced correctly
@@ -398,6 +396,9 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     const Real eps = 1.0e-7;
     const Spread basisPoint = 1.0e-4;
     auto engine = ext::make_shared<DiscountingSwapEngine>(nominalTS);
+
+    Handle<ZeroInflationTermStructure> hz(pZITS);
+    ii = ext::make_shared<UKRPI>(hz);
 
     for (const auto& datum: zcData) {
         ZeroCouponInflationSwap nzcis(Swap::Payer,
@@ -505,9 +506,6 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
                             << "\n    maturity: " << nzcis.maturityDate()
                             << "\n    rate:     " << datum.rate);
     }
-
-    // remove circular refernce
-    hz.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testZeroTermStructureLazyBaseDate) {
@@ -618,8 +616,7 @@ BOOST_AUTO_TEST_CASE(testSeasonalityCorrection) {
         202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
         207.3};
 
-    RelinkableHandle<ZeroInflationTermStructure> hz;
-    auto ii = ext::make_shared<UKRPI>(hz);
+    auto ii = ext::make_shared<UKRPI>();
     for (Size i=0; i<std::size(fixData); i++) {
         ii->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -667,9 +664,10 @@ BOOST_AUTO_TEST_CASE(testSeasonalityCorrection) {
 
     auto zeroCurve = ext::make_shared<InterpolatedZeroInflationCurve<Linear>>(
                                  evaluationDate, nodes, rates, frequency, dc);
-    hz.linkTo(zeroCurve);
 
-    // Perform checks on the seasonality for this non-interpolated index
+    Handle<ZeroInflationTermStructure> hz(zeroCurve);
+    ii = ext::make_shared<UKRPI>(hz);
+
     checkSeasonality(hz, ii);
 }
 
@@ -961,9 +959,8 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
         207.3
     };
 
-    RelinkableHandle<YoYInflationTermStructure> hy;
     auto rpi = ext::make_shared<UKRPI>();
-    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi);
     for (Size i=0; i<std::size(fixData); i++) {
         rpi->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -1022,7 +1019,8 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
     ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
 
     // make sure that the index has the latest yoy term structure
-    hy.linkTo(pYYTS);
+    Handle<YoYInflationTermStructure> hy(pYYTS);
+    iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
     for (Size j = 1; j < yyData.size(); j++) {
 
@@ -1093,8 +1091,6 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
                             <<", legs "<< yyS3.legNPV(0) << " and " << yyS3.legNPV(1)
                             );
     }
-    // remove circular refernce
-    hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
@@ -1120,9 +1116,8 @@ BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
         199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
         207.3};
 
-    RelinkableHandle<YoYInflationTermStructure> hy;
     auto rpi = ext::make_shared<UKRPI>();
-    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi);
     for (Size i = 0; i < std::size(fixData); i++) {
         rpi->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -1140,7 +1135,9 @@ BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
     auto yoyTs = ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
         evaluationDate, yoyDates, yoyRates, iir->frequency(), dc);
     yoyTs->enableExtrapolation();
-    hy.linkTo(yoyTs);
+
+    Handle<YoYInflationTermStructure> hy(yoyTs);
+    iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
     Schedule yoySchedule =
         MakeSchedule().from(nominalTS->referenceDate())
@@ -1166,8 +1163,6 @@ BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
     BOOST_CHECK_EXCEPTION(
         swap.fairSpread(), Error,
         ExpectedErrorMessage("result not available"));
-
-    hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
@@ -1193,9 +1188,8 @@ BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
         199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
         207.3};
 
-    RelinkableHandle<YoYInflationTermStructure> hy;
     auto rpi = ext::make_shared<UKRPI>();
-    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi);
     for (Size i = 0; i < std::size(fixData); i++) {
         rpi->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -1214,7 +1208,9 @@ BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
     auto yoyTs = ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
         evaluationDate, yoyDates, yoyRates, iir->frequency(), dc);
     yoyTs->enableExtrapolation();
-    hy.linkTo(yoyTs);
+
+    Handle<YoYInflationTermStructure> hy(yoyTs);
+    iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
     Schedule yoySchedule =
         MakeSchedule().from(nominalTS->referenceDate())
@@ -1239,8 +1235,6 @@ BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
     BOOST_CHECK_EXCEPTION(
         swap.fairSpread(), Error,
         ExpectedErrorMessage("result not available"));
-
-    hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testPeriod) {
@@ -1748,8 +1742,7 @@ BOOST_AUTO_TEST_CASE(testUsCpiLinearBootstrapAtMonthStart) {
 
         Settings::instance().evaluationDate() = evalDate;
 
-        RelinkableHandle<ZeroInflationTermStructure> hz;
-        auto index = ext::make_shared<USCPI>(hz);
+        auto index = ext::make_shared<USCPI>();
 
         for (auto& [d, v] : fixings)
             index->addFixing(d, v);
@@ -1767,7 +1760,6 @@ BOOST_AUTO_TEST_CASE(testUsCpiLinearBootstrapAtMonthStart) {
         try {
             auto curve = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             failureCount++;
@@ -1826,8 +1818,7 @@ BOOST_AUTO_TEST_CASE(testEuHicpFlatBootstrapAtMonthStart) {
 
         Settings::instance().evaluationDate() = evalDate;
 
-        RelinkableHandle<ZeroInflationTermStructure> hz;
-        auto index = ext::make_shared<EUHICPXT>(hz);
+        auto index = ext::make_shared<EUHICPXT>();
 
         for (auto& [d, v] : fixings)
             index->addFixing(d, v);
@@ -1846,20 +1837,16 @@ BOOST_AUTO_TEST_CASE(testEuHicpFlatBootstrapAtMonthStart) {
         try {
             auto curve = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             failureCount++;
         }
-
-        hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 
         // GlobalBootstrap
         try {
             auto curve = ext::make_shared<
                 PiecewiseZeroInflationCurve<Linear, GlobalBootstrap>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             globalFailureCount++;
@@ -1919,8 +1906,7 @@ BOOST_AUTO_TEST_CASE(testUkRpiFlatBootstrapAtMonthStart) {
 
         Settings::instance().evaluationDate() = evalDate;
 
-        RelinkableHandle<ZeroInflationTermStructure> hz;
-        auto index = ext::make_shared<UKRPI>(hz);
+        auto index = ext::make_shared<UKRPI>();
 
         for (auto& [d, v] : fixings)
             index->addFixing(d, v);
@@ -1940,20 +1926,16 @@ BOOST_AUTO_TEST_CASE(testUkRpiFlatBootstrapAtMonthStart) {
         try {
             auto curve = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             failureCount++;
         }
-
-        hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 
         // GlobalBootstrap
         try {
             auto curve = ext::make_shared<
                 PiecewiseZeroInflationCurve<Linear, GlobalBootstrap>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             globalFailureCount++;
@@ -2012,8 +1994,7 @@ BOOST_AUTO_TEST_CASE(testUsCpiLinearGlobalBootstrapAtMonthStart) {
 
         Settings::instance().evaluationDate() = evalDate;
 
-        RelinkableHandle<ZeroInflationTermStructure> hz;
-        auto index = ext::make_shared<USCPI>(hz);
+        auto index = ext::make_shared<USCPI>();
 
         for (auto& [d, v] : fixings)
             index->addFixing(d, v);
@@ -2032,7 +2013,6 @@ BOOST_AUTO_TEST_CASE(testUsCpiLinearGlobalBootstrapAtMonthStart) {
             auto curve = ext::make_shared<
                 PiecewiseZeroInflationCurve<Linear, GlobalBootstrap>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             failureCount++;
@@ -2103,8 +2083,7 @@ BOOST_AUTO_TEST_CASE(testPillarCollisionWithDifferentMonthLengths) {
 
         Settings::instance().evaluationDate() = evalDate;
 
-        RelinkableHandle<ZeroInflationTermStructure> hz;
-        auto index = ext::make_shared<USCPI>(hz);
+        auto index = ext::make_shared<USCPI>();
 
         for (auto& [d, v] : fixings)
             index->addFixing(d, v);
@@ -2122,7 +2101,6 @@ BOOST_AUTO_TEST_CASE(testPillarCollisionWithDifferentMonthLengths) {
         try {
             auto curve = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                 evalDate, baseDate, Monthly, dc, helpers);
-            hz.linkTo(curve);
             curve->zeroRate(evalDate + 1*Years);
         } catch (const std::exception&) {
             failureCount++;

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -101,9 +101,9 @@ struct CommonVars {
     DayCounter dc;
     ext::shared_ptr<YoYInflationIndex> iir;
 
-    RelinkableHandle<YieldTermStructure> nominalTS;
+    Handle<YieldTermStructure> nominalTS;
     ext::shared_ptr<YoYInflationTermStructure> yoyTS;
-    RelinkableHandle<YoYInflationTermStructure> hy;
+    Handle<YoYInflationTermStructure> hy;
 
     // setup
     CommonVars()
@@ -139,12 +139,11 @@ struct CommonVars {
         for (Size i=0; i<rpiSchedule.size();i++) {
             rpi->addFixing(rpiSchedule[i], fixData[i]);
         }
-        // link from yoy index to yoy TS
-        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+        iir = ext::make_shared<YoYInflationIndex>(rpi);
 
         ext::shared_ptr<YieldTermStructure> nominalFF(
                 new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
-        nominalTS.linkTo(nominalFF);
+        nominalTS = Handle<YieldTermStructure>(nominalFF);
 
         // now build the YoY inflation curve
         Period observationLag = Period(2,Months);
@@ -173,7 +172,7 @@ struct CommonVars {
                         CPI::Flat,
                         observationLag,
                         calendar, convention, dc,
-                        Handle<YieldTermStructure>(nominalTS));
+                        nominalTS);
 
         Date baseDate = rpi->lastFixingDate();
         Rate baseYYRate = yyData[0].rate/100.0;
@@ -183,7 +182,8 @@ struct CommonVars {
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
 
         // make sure that the index has the latest yoy term structure
-        hy.linkTo(pYYTS);
+        hy = Handle<YoYInflationTermStructure>(pYYTS);
+        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
     }
 
     // utilities
@@ -372,8 +372,6 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
             }
         }
     } // pricer loop
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 
@@ -427,8 +425,7 @@ BOOST_AUTO_TEST_CASE(testParity) {
                                                  0.0, // spread on index
                                                  vars.dc, UnitedKingdom());
 
-                    Handle<YieldTermStructure> hTS(vars.nominalTS);
-                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(vars.nominalTS));
                     swap.setPricingEngine(sppe);
 
                     // N.B. nominals are 10e6
@@ -445,8 +442,6 @@ BOOST_AUTO_TEST_CASE(testParity) {
             }
         }
     }
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testVolatilityQuoteObservability) {
@@ -487,9 +482,6 @@ BOOST_AUTO_TEST_CASE(testVolatilityQuoteObservability) {
     BOOST_CHECK_MESSAGE(relativeError(moved, expected, expected) < 1.0e-10,
                         "yoy cap priced off a quote of 0.02 gives " << moved
                         << ", off a value of 0.02 gives " << expected);
-
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testCachedValue) {
@@ -559,9 +551,6 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
     BOOST_CHECK_MESSAGE(fabs(floor->NPV()-cachedFloorNPVbac)<0.22,"yoy floor cached NPV wrong "
                         <<floor->NPV()<<" should be "<<cachedFloorNPVbac<<" bac Black pricer"
                         <<" diff was "<<(fabs(floor->NPV()-cachedFloorNPVbac)));
-
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -106,9 +106,9 @@ struct CommonVars {
     DayCounter dc;
     ext::shared_ptr<YoYInflationIndex> iir;
 
-    RelinkableHandle<YieldTermStructure> nominalTS;
+    Handle<YieldTermStructure> nominalTS;
     ext::shared_ptr<YoYInflationTermStructure> yoyTS;
-    RelinkableHandle<YoYInflationTermStructure> hy;
+    Handle<YoYInflationTermStructure> hy;
 
     // setup
     CommonVars()
@@ -147,12 +147,11 @@ struct CommonVars {
         for (Size i=0; i<rpiSchedule.size();i++) {
             rpi->addFixing(rpiSchedule[i], fixData[i]);
         }
-        // link from yoy index to yoy TS
-        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+        iir = ext::make_shared<YoYInflationIndex>(rpi);
 
         ext::shared_ptr<YieldTermStructure> nominalFF(
                         new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
-        nominalTS.linkTo(nominalFF);
+        nominalTS = Handle<YieldTermStructure>(nominalFF);
 
         // now build the YoY inflation curve
         Period observationLag = Period(2,Months);
@@ -181,7 +180,7 @@ struct CommonVars {
                         observationLag,
                         CPI::Flat,
                         calendar, convention, dc,
-                        Handle<YieldTermStructure>(nominalTS));
+                        nominalTS);
 
         Date baseDate = rpi->lastFixingDate();
         Rate baseYYRate = yyData[0].rate/100.0;
@@ -191,7 +190,8 @@ struct CommonVars {
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
 
         // make sure that the index has the latest yoy term structure
-        hy.linkTo(pYYTS);
+        hy = Handle<YoYInflationTermStructure>(pYYTS);
+        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
     }
 
     // utilities
@@ -674,8 +674,6 @@ BOOST_AUTO_TEST_CASE(testDecomposition) {
                     << "\n" <<
                     "  Diff: " << error );
     }
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 BOOST_AUTO_TEST_CASE(testInstrumentEquality) {
@@ -729,8 +727,7 @@ BOOST_AUTO_TEST_CASE(testInstrumentEquality) {
                                                  vars.dc,
                                                  UnitedKingdom());
 
-                    Handle<YieldTermStructure> hTS(vars.nominalTS);
-                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(vars.nominalTS));
                     swap.setPricingEngine(sppe);
 
                     Leg leg2 = vars.makeYoYCapFlooredLeg(whichPricer, from, length,
@@ -775,8 +772,6 @@ BOOST_AUTO_TEST_CASE(testInstrumentEquality) {
             }
         }
     }
-    // remove circular refernce
-    vars.hy.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -83,8 +83,8 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
 
     ext::shared_ptr<UKRPI> ii;
 
-    RelinkableHandle<YieldTermStructure> yTS;
-    RelinkableHandle<ZeroInflationTermStructure> cpiTS;
+    Handle<YieldTermStructure> yTS;
+    Handle<ZeroInflationTermStructure> cpiTS;
 
     // setup
     CommonVars() {
@@ -96,7 +96,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
         Settings::instance().evaluationDate() = evaluationDate;
         dayCounter = ActualActual(ActualActual::ISDA);
 
-        ii = ext::make_shared<UKRPI>(cpiTS);
+        ii = ext::make_shared<UKRPI>();
 
         Schedule rpiSchedule =
             MakeSchedule()
@@ -115,7 +115,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
             ii->addFixing(rpiSchedule[i], fixData[i]);
         }
 
-        yTS.linkTo(ext::shared_ptr<YieldTermStructure>(
+        yTS = Handle<YieldTermStructure>(ext::shared_ptr<YieldTermStructure>(
                           new FlatForward(evaluationDate, 0.05, dayCounter)));
 
         // now build the zero inflation curve
@@ -147,14 +147,11 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
 
         Date baseDate = ii->lastFixingDate();
 
-        cpiTS.linkTo(ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
+        cpiTS = Handle<ZeroInflationTermStructure>(
+            ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                          evaluationDate, baseDate, ii->frequency(), dayCounter, helpers));
-    }
 
-    // teardown
-    ~CommonVars() {
-        // break circular references and allow curves to be destroyed
-        cpiTS.reset();
+        ii = ext::make_shared<UKRPI>(cpiTS);
     }
 };
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -103,9 +103,8 @@ struct CommonVars {
     ext::shared_ptr<UKRPI> ii;
     Size zciisDataLength;
 
-    RelinkableHandle<YieldTermStructure> nominalUK;
-    RelinkableHandle<ZeroInflationTermStructure> cpiUK;
-    RelinkableHandle<ZeroInflationTermStructure> hcpi;
+    Handle<YieldTermStructure> nominalUK;
+    Handle<ZeroInflationTermStructure> cpiUK;
 
     std::vector<Rate> cStrikesUK;
     std::vector<Rate> fStrikesUK;
@@ -118,7 +117,6 @@ struct CommonVars {
     // setup
     CommonVars()
     : nominals(1,1000000) {
-        //std::cout <<"CommonVars" << std::endl;
         // option variables
         frequency = Annual;
         // usual setup
@@ -152,7 +150,7 @@ struct CommonVars {
         };
 
         // link from cpi index to cpi TS
-        ii = ext::make_shared<UKRPI>(hcpi);
+        ii = ext::make_shared<UKRPI>();
         for (Size i=0; i<rpiSchedule.size();i++) {
             ii->addFixing(rpiSchedule[i], fixData[i], true);// force overwrite in case multiple use
         };
@@ -203,7 +201,7 @@ struct CommonVars {
         ext::shared_ptr<YieldTermStructure> nominalTS =
             ext::make_shared<InterpolatedZeroCurve<Linear>>(nomD,nomR,dcNominal);
 
-        nominalUK.linkTo(nominalTS);
+        nominalUK = Handle<YieldTermStructure>(nominalTS);
 
 
         // now build the zero inflation curve
@@ -249,11 +247,11 @@ struct CommonVars {
         Date baseDate = ii->lastFixingDate();
         auto pCPIts = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                                     evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);
-        pCPIts->recalculate();
-        cpiUK.linkTo(pCPIts);
+
+        cpiUK = Handle<ZeroInflationTermStructure>(pCPIts);
 
         // make sure that the index has the latest zero inflation term structure
-        hcpi.linkTo(pCPIts);
+        ii = ext::make_shared<UKRPI>(cpiUK);
 
         // cpi CF price surf data
         Period cfMat[] = {3*Years, 5*Years, 7*Years, 10*Years, 15*Years, 20*Years, 30*Years};
@@ -362,9 +360,6 @@ BOOST_AUTO_TEST_CASE(cpicapfloorpricesurface) {
         BOOST_ERROR("The requested premium, " << premium
             << ", does not equal the expected premium, " << expPremium << ".");
     }
-
-    // remove circular refernce
-    common.hcpi.reset();
 }
 
 BOOST_AUTO_TEST_CASE(cpicapfloorpricer) {
@@ -424,9 +419,6 @@ BOOST_AUTO_TEST_CASE(cpicapfloorpricer) {
 
     QL_REQUIRE(fabs(cached - aCap.NPV())<1e-10,"InterpolatingCPICapFloorEngine does not reproduce cached price: "
                << cached << " vs " << aCap.NPV());
-
-    // remove circular refernce
-    common.hcpi.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -98,9 +98,9 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
     ext::shared_ptr<UKRPI> ii;
     Size zciisDataLength;
 
-    RelinkableHandle<YieldTermStructure> nominalTS;
+    Handle<YieldTermStructure> nominalTS;
     ext::shared_ptr<ZeroInflationTermStructure> cpiTS;
-    RelinkableHandle<ZeroInflationTermStructure> hcpi;
+    Handle<ZeroInflationTermStructure> hcpi;
 
     // setup
     CommonVars()
@@ -138,7 +138,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
         };
 
         // link from cpi index to cpi TS
-        ii = ext::make_shared<UKRPI>(hcpi);
+        ii = ext::make_shared<UKRPI>();
         for (Size i=0; i<rpiSchedule.size();i++) {
             ii->addFixing(rpiSchedule[i], fixData[i], true);// force overwrite in case multiple use
         };
@@ -186,7 +186,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
         ext::shared_ptr<YieldTermStructure> nominal =
             ext::make_shared<InterpolatedZeroCurve<Linear>>(nomD,nomR,dcNominal);
 
-        nominalTS.linkTo(nominal);
+        nominalTS = Handle<YieldTermStructure>(nominal);
 
         // now build the zero inflation curve
         observationLag = Period(2,Months);
@@ -231,17 +231,12 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
         auto pCPIts =
             ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                                     evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);
-        pCPIts->recalculate();
+
         cpiTS = ext::dynamic_pointer_cast<ZeroInflationTermStructure>(pCPIts);
 
         // make sure that the index has the latest zero inflation term structure
-        hcpi.linkTo(pCPIts);
-    }
-
-    // teardown
-    ~CommonVars() {
-        // break circular references and allow curves to be destroyed
-        hcpi.reset();
+        hcpi = Handle<ZeroInflationTermStructure>(pCPIts);
+        ii = ext::make_shared<UKRPI>(hcpi);
     }
 };
 


### PR DESCRIPTION
Before version 1.34, inflation indexes always needed an inflation term structure, even if they weren't used for forecasting.

In some of our tests, this forced us to use a setup in which a circular reference was created: an index would be given a handle, a piecewise inflation curve would be given the index, and the curve would be linked to the handle so that the index would have a curve available during bootstrapping.  At the end of the test, the cycle would be broken by linking the handle to a null pointer so that the objects could be destroyed.

This is no longer necessary. The index required by the curve can now be created with an empty handle.

This commit reworks the setup of the affected tests so that the obsolete pattern is no longer used (and possibly copied when writing new tests).