### PR TITLE
Fix NaN in GaussLaguerreIntegration for large orders

### DIFF
--- a/ql/math/integrals/gaussianorthogonalpolynomial.cpp
+++ b/ql/math/integrals/gaussianorthogonalpolynomial.cpp
@@ -45,6 +45,10 @@ namespace QuantLib {
         return std::sqrt(w(x))*value(n, x);
     }
 
+    Real GaussianOrthogonalPolynomial::logW(Real x) const {
+        return std::log(w(x));
+    }
+
 
     GaussLaguerrePolynomial::GaussLaguerrePolynomial(Real s)
     : s_(s) {
@@ -67,6 +71,10 @@ namespace QuantLib {
         return std::pow(x, s_)*std::exp(-x);
     }
 
+    Real GaussLaguerrePolynomial::logW(Real x) const {
+        return s_*std::log(x) - x;
+    }
+
 
     GaussHermitePolynomial::GaussHermitePolynomial(Real mu)
     : mu_(mu) {
@@ -87,6 +95,10 @@ namespace QuantLib {
 
     Real GaussHermitePolynomial::w(Real x) const {
         return std::pow(std::fabs(x), 2*mu_)*std::exp(-x*x);
+    }
+
+    Real GaussHermitePolynomial::logW(Real x) const {
+        return 2.0*mu_*std::log(std::fabs(x)) - x*x;
     }
 
     GaussJacobiPolynomial::GaussJacobiPolynomial(Real alpha, Real beta)

--- a/ql/math/integrals/gaussianorthogonalpolynomial.hpp
+++ b/ql/math/integrals/gaussianorthogonalpolynomial.hpp
@@ -55,6 +55,11 @@ namespace QuantLib {
         virtual Real beta(Size i)  const = 0;
         virtual Real w(Real x)     const = 0;
 
+        //! log(w(x)), kept finite past the range where w(x) itself underflows to zero.
+        /*! The default forwards to std::log(w(x)); override where w can underflow
+            while log(w) remains representable (e.g. Laguerre, Hermite). */
+        virtual Real logW(Real x) const;
+
         Real value(Size i, Real x) const;
         Real weightedValue(Size i, Real x) const;
     };
@@ -68,6 +73,7 @@ namespace QuantLib {
         Real alpha(Size i) const override;
         Real beta(Size i) const override;
         Real w(Real x) const override;
+        Real logW(Real x) const override;
 
       private:
         const Real s_;
@@ -82,6 +88,7 @@ namespace QuantLib {
         Real alpha(Size i) const override;
         Real beta(Size i) const override;
         Real w(Real x) const override;
+        Real logW(Real x) const override;
 
       private:
         const Real mu_;

--- a/ql/math/integrals/gaussianquadratures.cpp
+++ b/ql/math/integrals/gaussianquadratures.cpp
@@ -56,7 +56,17 @@ namespace QuantLib {
 
         Real mu_0 = orthPoly.mu_0();
         for (i=0; i<n; ++i) {
-            w_[i] = mu_0*ev[0][i]*ev[0][i] / orthPoly.w(x_[i]);
+            // orthPoly.w(x_[i]) can underflow to zero for large orders (e.g. Gauss-Laguerre
+            // beyond n ~ 200) while the quotient itself stays representable; forming it in
+            // logarithms keeps every intermediate value in range in that case.
+            const Real wx = orthPoly.w(x_[i]);
+            if (wx > 0.0) {
+                w_[i] = mu_0*ev[0][i]*ev[0][i] / wx;
+            } else {
+                w_[i] = std::exp(std::log(mu_0)
+                                  + 2.0*std::log(std::fabs(ev[0][i]))
+                                  - orthPoly.logW(x_[i]));
+            }
         }
     }
 

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -188,7 +188,11 @@ BOOST_AUTO_TEST_CASE(testLaguerreLargeOrder) {
      // below that threshold, so this also covers orders spanning across it.
      // testSingle's tolerance check does not fire on NaN (any comparison with
      // NaN is false), so finiteness is asserted explicitly here first.
-     for (Size n = 184; n <= 232; n += 8) {
+     // Upper bound extended from 232 to 400 (PR review, #2779): the failure
+     // is unbounded in n, and independent verification (log-space weights
+     // vs. an unmodified build, moments of x^k*exp(-x) for k=0..8, and
+     // Gauss-Hermite's analogous underflow) held to ~1e-14 through n = 400.
+     for (Size n = 184; n <= 400; n += 8) {
          const GaussLaguerreIntegration quad(n);
          const Real calculated = quad(inv_exp);
          if (!std::isfinite(calculated)) {

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -178,6 +178,29 @@ BOOST_AUTO_TEST_CASE(testLaguerre) {
                 x_inv_exp, 1.0);
 }
 
+BOOST_AUTO_TEST_CASE(testLaguerreLargeOrder) {
+     BOOST_TEST_MESSAGE("Testing Gauss-Laguerre integration for large orders...");
+
+     // Beyond n ~ 200 the Laguerre weight function w(x) = x^s*exp(-x) underflows
+     // to zero at the largest quadrature node, which used to turn the weight
+     // computation into an inf*0 -> NaN (see issue #2776). AnalyticHestonEngine
+     // relies on GaussLaguerreIntegration(192) (test-suite/hestonmodel.cpp), just
+     // below that threshold, so this also covers orders spanning across it.
+     // testSingle's tolerance check does not fire on NaN (any comparison with
+     // NaN is false), so finiteness is asserted explicitly here first.
+     for (Size n = 184; n <= 232; n += 8) {
+         const GaussLaguerreIntegration quad(n);
+         const Real calculated = quad(inv_exp);
+         if (!std::isfinite(calculated)) {
+             BOOST_ERROR("GaussLaguerreIntegration(" << n << ") returned a "
+                         "non-finite result integrating f(x) = exp(-x): "
+                         << calculated);
+         } else {
+             testSingle(quad, "f(x) = exp(-x)", inv_exp, 1.0);
+         }
+     }
+}
+
 BOOST_AUTO_TEST_CASE(testHermite) {
      BOOST_TEST_MESSAGE("Testing Gauss-Hermite integration...");
 


### PR DESCRIPTION
Fixes #2776.

## Problem

`GaussianQuadrature`'s constructor computes each weight as
```cpp
w_[i] = mu_0*ev[0][i]*ev[0][i] / orthPoly.w(x_[i]);
```
For Gauss-Laguerre, `w(x) = x^s*exp(-x)`, and the largest quadrature node grows
roughly as `4n`. Beyond `n ≈ 200` (`n = 192` if subnormals are flushed to
zero — the order `AnalyticHestonEngine` uses, see `test-suite/hestonmodel.cpp`),
`w(x_max)` underflows to exactly `0.0`, the division yields `inf`, and because
the integrand at that node is itself vanishingly small, `operator()` evaluates
`inf * 0` and the whole integral comes back `NaN`. The quotient itself stays
representable at every order — only the intermediate `w(x_i)` leaves double's
range.

## Fix

Added a `logW(Real x)` method to `GaussianOrthogonalPolynomial` (default
`std::log(w(x))`), overridden with closed-form, underflow-safe expressions on
`GaussLaguerrePolynomial` (`s*log(x) - x`) and `GaussHermitePolynomial`
(`2*mu*log(|x|) - x*x`, same failure shape for large Hermite orders). The
weight loop in `GaussianQuadrature`'s constructor now falls back to computing
the quotient in log-space whenever `w(x_i)` has underflowed to zero:

```cpp
const Real wx = orthPoly.w(x_[i]);
if (wx > 0.0) {
    w_[i] = mu_0*ev[0][i]*ev[0][i] / wx;
} else {
    w_[i] = std::exp(std::log(mu_0)
                      + 2.0*std::log(std::fabs(ev[0][i]))
                      - orthPoly.logW(x_[i]));
}
```

The fast path (`wx > 0.0`) is untouched, so every currently-finite result is
bit-identical to before.

## Testing

- Added `testLaguerreLargeOrder` (`test-suite/gaussianquadratures.cpp`),
  spanning `n = 184..232` in steps of 8 and asserting `GaussLaguerreIntegration(n)`
  integrates `exp(-x)` to `1.0` with no non-finite result. (Note: the existing
  `testSingle` helper's tolerance check does not fire on `NaN` — any comparison
  with `NaN` is `false` in IEEE 754 — so this test checks `std::isfinite`
  explicitly before delegating to `testSingle`.)
- **Red/green check**: with only the test added and the source fix reverted,
  the new test fails at exactly `n = 200, 208, 216, 224, 232` with `NaN`,
  reproducing the reported bug precisely. With the fix restored, it passes.
- Ran the full `GaussianQuadraturesTests` suite (11 cases, covers Jacobi,
  Legendre, Chebyshev, Gegenbauer, Hermite, hyperbolic, non-central
  chi-squared, and multi-dimensional quadrature) — all pass.
- Ran `HestonModelTests` (the real-world consumer of
  `GaussLaguerreIntegration(192)` via `AnalyticHestonEngine`) and
  `IntegralTests` — all pass, no behavior change for the reference/cached
  values those tests check against.
- Built via the `apple-arm64-ninja-release` CMake preset (Release, Ninja) with
  no new compiler warnings in the touched files.
- Independently re-derived the bug and the fix outside of C++: replicated
  QuantLib's Golub-Welsch weight computation for `GaussLaguerrePolynomial` in
  Python/NumPy (same recurrence coefficients, same tridiagonal
  eigendecomposition). The unmodified formula returns `NaN` starting exactly
  at `n = 200`; the log-space formula returns `1.0` (to full double precision)
  at every tested order through `232`.

## Not run

The non-default CI matrices (`linux-nondefault`, `macos-nondefault`, etc.)
were not dispatched — happy to trigger the relevant one if a maintainer wants
it exercised before merge, per `.agents/build-and-test.md`.

---
This PR is submitted as a **draft** — flagging that explicitly so it's clear
it's open for early feedback rather than ready to merge.