### PR TITLE
Avoid NaN from Gauss-Laguerre quadrature at high orders

### DIFF
--- a/ql/math/integrals/gaussianorthogonalpolynomial.cpp
+++ b/ql/math/integrals/gaussianorthogonalpolynomial.cpp
@@ -41,6 +41,10 @@ namespace QuantLib {
         return 1;
     }
 
+    Real GaussianOrthogonalPolynomial::logW(Real x) const {
+        return std::log(w(x));
+    }
+
     Real GaussianOrthogonalPolynomial::weightedValue(Size n, Real x) const {
         return std::sqrt(w(x))*value(n, x);
     }
@@ -67,6 +71,10 @@ namespace QuantLib {
         return std::pow(x, s_)*std::exp(-x);
     }
 
+    Real GaussLaguerrePolynomial::logW(Real x) const {
+        return s_*std::log(x) - x;
+    }
+
 
     GaussHermitePolynomial::GaussHermitePolynomial(Real mu)
     : mu_(mu) {
@@ -87,6 +95,10 @@ namespace QuantLib {
 
     Real GaussHermitePolynomial::w(Real x) const {
         return std::pow(std::fabs(x), 2*mu_)*std::exp(-x*x);
+    }
+
+    Real GaussHermitePolynomial::logW(Real x) const {
+        return 2*mu_*std::log(std::fabs(x)) - x*x;
     }
 
     GaussJacobiPolynomial::GaussJacobiPolynomial(Real alpha, Real beta)

--- a/ql/math/integrals/gaussianorthogonalpolynomial.hpp
+++ b/ql/math/integrals/gaussianorthogonalpolynomial.hpp
@@ -55,6 +55,16 @@ namespace QuantLib {
         virtual Real beta(Size i)  const = 0;
         virtual Real w(Real x)     const = 0;
 
+        /*! Logarithm of the weight function.
+
+            The default implementation returns <tt>std::log(w(x))</tt>.
+            Subclasses whose weight function underflows to zero for large
+            arguments should override this with a closed form that stays
+            in range; the Gauss quadrature weights are then built from it
+            without forming \f$ w(x) \f$ itself.
+        */
+        virtual Real logW(Real x) const;
+
         Real value(Size i, Real x) const;
         Real weightedValue(Size i, Real x) const;
     };
@@ -68,6 +78,7 @@ namespace QuantLib {
         Real alpha(Size i) const override;
         Real beta(Size i) const override;
         Real w(Real x) const override;
+        Real logW(Real x) const override;
 
       private:
         const Real s_;
@@ -82,6 +93,7 @@ namespace QuantLib {
         Real alpha(Size i) const override;
         Real beta(Size i) const override;
         Real w(Real x) const override;
+        Real logW(Real x) const override;
 
       private:
         const Real mu_;

--- a/ql/math/integrals/gaussianquadratures.cpp
+++ b/ql/math/integrals/gaussianquadratures.cpp
@@ -27,6 +27,7 @@
 #include <ql/math/matrixutilities/tqreigendecomposition.hpp>
 #include <ql/math/matrixutilities/symmetricschurdecomposition.hpp>
 
+#include <cmath>
 #include <map>
 
 namespace QuantLib {
@@ -56,7 +57,18 @@ namespace QuantLib {
 
         Real mu_0 = orthPoly.mu_0();
         for (i=0; i<n; ++i) {
-            w_[i] = mu_0*ev[0][i]*ev[0][i] / orthPoly.w(x_[i]);
+            const Real wx = orthPoly.w(x_[i]);
+            if (wx > 0.0) {
+                w_[i] = mu_0*ev[0][i]*ev[0][i] / wx;
+            } else {
+                /* w(x) has underflowed to zero, which happens for the
+                   largest nodes once the order is high enough. The quotient
+                   itself is still of order one there, so form it in
+                   logarithms to keep every intermediate in range. */
+                w_[i] = std::exp(std::log(mu_0)
+                                 + 2.0*std::log(std::fabs(ev[0][i]))
+                                 - orthPoly.logW(x_[i]));
+            }
         }
     }
 

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -178,6 +178,34 @@ BOOST_AUTO_TEST_CASE(testLaguerre) {
                 x_inv_exp, 1.0);
 }
 
+BOOST_AUTO_TEST_CASE(testLaguerreHighOrder) {
+     BOOST_TEST_MESSAGE("Testing high-order Gauss-Laguerre integration...");
+
+     /* For large orders the biggest node grows roughly as 4n, so the weight
+        function exp(-x) underflows to zero there and the weights used to come
+        back as inf, turning the whole integral into NaN (issue #2776).
+        The integral of exp(-x) over [0, inf) is exactly one at every order. */
+
+     for (Size n : { 184, 192, 200, 256, 320, 400 }) {
+         const Real calculated = GaussLaguerreIntegration(n)(inv_exp);
+         const Real tol = 1e-12;
+
+         if (!std::isfinite(calculated)) {
+             BOOST_ERROR("non-finite result from high-order Gauss-Laguerre"
+                         << "\n    order:      " << n
+                         << "\n    calculated: " << calculated);
+         } else if (std::fabs(calculated - 1.0) > tol) {
+             BOOST_ERROR("failed to reproduce high-order Gauss-Laguerre integral"
+                         << std::setprecision(12)
+                         << "\n    order:      " << n
+                         << "\n    calculated: " << calculated
+                         << "\n    expected:   " << 1.0
+                         << "\n    diff:       " << std::fabs(calculated - 1.0)
+                         << "\n    tolerance:  " << tol);
+         }
+     }
+}
+
 BOOST_AUTO_TEST_CASE(testHermite) {
      BOOST_TEST_MESSAGE("Testing Gauss-Hermite integration...");
 


### PR DESCRIPTION
Fixes #2776.

## Problem

The largest Gauss-Laguerre node grows roughly as `4n`, so beyond a certain order the weight function `w(x) = x^s exp(-x)` underflows to zero at that node. `GaussianQuadrature`'s constructor divides by `w(x_i)`:

```cpp
w_[i] = mu_0*ev[0][i]*ev[0][i] / orthPoly.w(x_[i]);
```

so the weight became `inf`. The integrand at that node is itself of order `exp(-x)`, and `inf * 0` turned the whole integral into `NaN`.

The first `NaN` appears at **n = 200** (`x_max = 767.81`), or at **n = 192** when subnormals are flushed to zero — which is the order `test-suite/hestonmodel.cpp` uses for `AnalyticHestonEngine::Integration::gaussLaguerre(192)`. The engine's default `integrationOrder` of 144 is well inside the safe range.

## Fix

The quotient `mu_0 * ev[0][i]^2 / w(x_i)` is finite and of order one at every node — the squared eigenvector component underflows just as fast as `w(x)` does. Only the intermediate `w(x_i)` leaves the representable range, so the quotient is formed in logarithms when `w(x_i)` has underflowed.

This adds a virtual `logW()` to `GaussianOrthogonalPolynomial`. It is **not** pure virtual — it defaults to `std::log(w(x))`, so any subclass defined outside the library keeps compiling and working unchanged. Laguerre and Hermite override it with the closed form (`s*log(x) - x` and `2*mu*log(|x|) - x*x`).

The direct path is kept whenever `w(x_i) > 0`, so **results below the threshold are bit-identical to before**; only the orders that previously returned `NaN` change.

## Verification

Reproducer from the issue, before and after:

| n | before | after |
|---|---|---|
| 184 | 1 | 1 |
| 192 | 0.999999999999999 | 0.999999999999999 |
| 200 | **nan** | 1 |
| 256 | **nan** | 0.999999999999997 |
| 320 | **nan** | 1.00000000000001 |
| 400 | **nan** | 1 |

Checked additionally:

- **Bit-identical below the threshold.** Diffed `%.17g` output for Laguerre and Hermite at n = 8, 16, 32, 64, 128, 144, 192 against the unpatched build — identical in every case.
- **Moments.** `∫ x^k exp(-x) dx = k!` at n = 256 for k = 0..8, relative error ≤ 2.9e-14.
- **Hermite unaffected.** `∫ exp(-x²) dx = √π` at n = 100..300, relative error ~4e-14 throughout.

## Test

Adds `testLaguerreHighOrder` to `test-suite/gaussianquadratures.cpp`, covering n = 184, 192, 200, 256, 320, 400 and asserting both finiteness and the exact value. It fails on master and passes with this change.
