### PR TITLE
Improve test coverage for normal distribution + minor edge-case fix

### DIFF
--- a/ql/math/distributions/normaldistribution.cpp
+++ b/ql/math/distributions/normaldistribution.cpp
@@ -145,7 +145,10 @@ namespace QuantLib {
         Real result;
         Real temp=x-0.5;
 
-        if (std::fabs(temp) < 0.42) {
+        // Moro's central approximation is used for |x - 0.5| < 0.42;
+        // the alternative approximation is more accurate in the tails.
+        constexpr Real centralRegionHalfWidth = 0.42;
+        if (std::fabs(temp) < centralRegionHalfWidth) {
             // Beasley and Springer, 1977
             result=temp*temp;
             result=temp*

--- a/ql/math/distributions/normaldistribution.cpp
+++ b/ql/math/distributions/normaldistribution.cpp
@@ -170,7 +170,12 @@ namespace QuantLib {
 
     MaddockInverseCumulativeNormal::MaddockInverseCumulativeNormal(
         Real average, Real sigma)
-    : average_(average), sigma_(sigma) {}
+    : average_(average), sigma_(sigma) {
+
+        QL_REQUIRE(sigma_ > 0.0,
+                   "sigma must be greater than 0.0 ("
+                   << sigma_ << " not allowed)");
+    }
 
     Real MaddockInverseCumulativeNormal::operator()(Real x) const {
         return boost::math::quantile(
@@ -179,7 +184,12 @@ namespace QuantLib {
 
     MaddockCumulativeNormal::MaddockCumulativeNormal(
         Real average, Real sigma)
-    : average_(average), sigma_(sigma) {}
+    : average_(average), sigma_(sigma) {
+
+        QL_REQUIRE(sigma_ > 0.0,
+                   "sigma must be greater than 0.0 ("
+                   << sigma_ << " not allowed)");
+    }
 
     Real MaddockCumulativeNormal::operator()(Real x) const {
         return boost::math::cdf(

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -35,6 +35,14 @@ namespace QuantLib {
     /*! Given x, it returns its probability in a Gaussian normal distribution.
         It provides the first derivative too.
 
+      For average $ \mu $ and standard deviation $ \sigma $, the
+      density is
+      [
+        f(x) = \frac{1}{\sigma\sqrt{2\pi}}
+             \exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
+      ]
+      The standard deviation must be strictly positive.
+
         \test the correctness of the returned value is tested by
               checking it against numerical calculations. Cross-checks
               are also performed against the
@@ -57,9 +65,17 @@ namespace QuantLib {
 
 
     //! Cumulative normal distribution function
-    /*! Given x it provides an approximation to the
-        integral of the gaussian normal distribution:
-        formula here ...
+    /*! Given x, it provides an approximation to the cumulative probability
+      of a Gaussian normal distribution with average $ \mu $ and
+      standard deviation $ \sigma $:
+      [
+        F(x) = \frac{1}{\sigma\sqrt{2\pi}}
+             \int_{-\infty}^{x}
+             \exp\left(-\frac{(t-\mu)^2}{2\sigma^2}\right)dt.
+      ]
+      The result is between zero and one, and derivative() returns the
+      corresponding normal density. The lower tail uses an asymptotic
+      expansion when the direct error-function calculation loses precision.
 
         For this implementation see M. Abramowitz and I. Stegun,
         Handbook of Mathematical Functions,
@@ -80,12 +96,14 @@ namespace QuantLib {
 
 
     //! Inverse cumulative normal distribution function
-    /*! Given x between zero and one as
-      the integral value of a gaussian normal distribution
-      this class provides the value y such that
-      formula here ...
+    /*! Given a probability $ p $ between zero and one, this class
+      provides $ y = F^{-1}(p) $ such that
+      \f[
+          F(y) = p,
+      \f]
+      where $ F $ is the cumulative normal distribution.
 
-      It use Acklam's approximation:
+      It uses Acklam's approximation:
       by Peter J. Acklam, University of Oslo, Statistics Division.
       URL: http://home.online.no/~pjacklam/notes/invnorm/index.html
 
@@ -181,8 +199,8 @@ namespace QuantLib {
         this class provides the value y such that
         formula here ...
 
-        It uses Beasly and Springer approximation, with an improved
-        approximation for the tails. See Boris Moro,
+        It uses the Beasley-Springer approximation in the central region,
+        with an improved Moro approximation for the tails. See Boris Moro,
         "The Full Monte", 1995, Risk Magazine.
 
         This class can also be used to generate a gaussian normal
@@ -223,10 +241,12 @@ namespace QuantLib {
     };
 
     //! Maddock's Inverse cumulative normal distribution class
-    /*! Given x between zero and one as
-        the integral value of a gaussian normal distribution
-        this class provides the value y such that
-        formula here ...
+    /*! Given a probability $ p $ between zero and one, this class
+      provides $ y = F^{-1}(p) $ such that
+      [
+        F(y) = p,
+      ]
+      where $ F $ is the cumulative normal distribution.
 
         From the boost documentation:
          These functions use a rational approximation devised by

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -35,12 +35,12 @@ namespace QuantLib {
     /*! Given x, it returns its probability in a Gaussian normal distribution.
         It provides the first derivative too.
 
-      For average $ \mu $ and standard deviation $ \sigma $, the
+      For average \f$ \mu \f$ and standard deviation \f$ \sigma \f$, the
       density is
-      [
+      \f[
         f(x) = \frac{1}{\sigma\sqrt{2\pi}}
              \exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
-      ]
+      \f]
       The standard deviation must be strictly positive.
 
         \test the correctness of the returned value is tested by
@@ -66,13 +66,13 @@ namespace QuantLib {
 
     //! Cumulative normal distribution function
     /*! Given x, it provides an approximation to the cumulative probability
-      of a Gaussian normal distribution with average $ \mu $ and
-      standard deviation $ \sigma $:
-      [
+      of a Gaussian normal distribution with average \f$ \mu \f$ and
+      standard deviation \f$ \sigma \f$:
+      \f[
         F(x) = \frac{1}{\sigma\sqrt{2\pi}}
              \int_{-\infty}^{x}
              \exp\left(-\frac{(t-\mu)^2}{2\sigma^2}\right)dt.
-      ]
+      \f]
       The result is between zero and one, and derivative() returns the
       corresponding normal density. The lower tail uses an asymptotic
       expansion when the direct error-function calculation loses precision.
@@ -96,12 +96,12 @@ namespace QuantLib {
 
 
     //! Inverse cumulative normal distribution function
-    /*! Given a probability $ p $ between zero and one, this class
-      provides $ y = F^{-1}(p) $ such that
+    /*! Given a probability \f$ p \f$ between zero and one, this class
+      provides \f$ y = F^{-1}(p) \f$ such that
       \f[
           F(y) = p,
       \f]
-      where $ F $ is the cumulative normal distribution.
+      where \f$ F \f$ is the cumulative normal distribution.
 
       It uses Acklam's approximation:
       by Peter J. Acklam, University of Oslo, Statistics Division.
@@ -241,12 +241,12 @@ namespace QuantLib {
     };
 
     //! Maddock's Inverse cumulative normal distribution class
-    /*! Given a probability $ p $ between zero and one, this class
-      provides $ y = F^{-1}(p) $ such that
-      [
+    /*! Given a probability \f$ p \f$ between zero and one, this class
+      provides \f$ y = F^{-1}(p) \f$ such that
+      \f[
         F(y) = p,
-      ]
-      where $ F $ is the cumulative normal distribution.
+      \f]
+      where \f$ F \f$ is the cumulative normal distribution.
 
         From the boost documentation:
          These functions use a rational approximation devised by

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -281,9 +281,9 @@ namespace QuantLib {
     }
 
     inline Real NormalDistribution::derivative(Real x) const {
-      const Real density = (*this)(x);
-      return density == 0.0 ? 0.0 :
-        (density * (average_ - x)) / derNormalizationFactor_;
+        const Real density = (*this)(x);
+        return density == 0.0 ? 0.0 :
+            (density * (average_ - x)) / derNormalizationFactor_;
     }
 
     inline CumulativeNormalDistribution::CumulativeNormalDistribution(

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -281,7 +281,9 @@ namespace QuantLib {
     }
 
     inline Real NormalDistribution::derivative(Real x) const {
-        return ((*this)(x) * (average_ - x)) / derNormalizationFactor_;
+      const Real density = (*this)(x);
+      return density == 0.0 ? 0.0 :
+        (density * (average_ - x)) / derNormalizationFactor_;
     }
 
     inline CumulativeNormalDistribution::CumulativeNormalDistribution(

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -361,6 +361,17 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
     BOOST_CHECK(std::isfinite(moroInvCum(0.080001)));
     BOOST_CHECK(std::isfinite(moroInvCum(0.919999)));
     BOOST_CHECK(std::isfinite(moroInvCum(0.92)));
+    for (Real probability : { 0.08, 0.080001, 0.919999, 0.92 }) {
+        BOOST_CHECK_CLOSE(moroInvCum(probability), invCum(probability), 1.0e-3);
+    }
+    BOOST_CHECK_SMALL(
+        std::fabs((moroInvCum(0.080001) - moroInvCum(0.08)) -
+                  (invCum(0.080001) - invCum(0.08))),
+        1.0e-4);
+    BOOST_CHECK_SMALL(
+        std::fabs((moroInvCum(0.92) - moroInvCum(0.919999)) -
+                  (invCum(0.92) - invCum(0.919999))),
+        1.0e-4);
 
     MaddockInverseCumulativeNormal maddockInvCum;
     BOOST_CHECK(std::isfinite(maddockInvCum(0.5)));

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(testNormal) {
 
     e = norm(diff.begin(), diff.end(), h);
     if (e > 1.0e-7) {
-        BOOST_ERROR("norm of MaddokInvCum . cum minus identity: "
+        BOOST_ERROR("norm of MaddockInvCum . cum minus identity: "
                     << std::scientific << e << "\n"
                     << "tolerance exceeded");
     }
@@ -366,21 +366,26 @@ BOOST_AUTO_TEST_CASE(testMoroInverseCumulativeNormal) {
     BOOST_CHECK_THROW(moroInvCum(1.0), Error);
     BOOST_CHECK_THROW(moroInvCum(-1.0e-8), Error);
     BOOST_CHECK_THROW(moroInvCum(1.0 + 1.0e-8), Error);
-    BOOST_CHECK(std::isfinite(moroInvCum(0.08)));
-    BOOST_CHECK(std::isfinite(moroInvCum(0.080001)));
-    BOOST_CHECK(std::isfinite(moroInvCum(0.919999)));
-    BOOST_CHECK(std::isfinite(moroInvCum(0.92)));
-    for (Real probability : { 0.08, 0.080001, 0.919999, 0.92 }) {
+
+    // Moro switches from its tail approximation to the central approximation
+    // at |p - 0.5| = 0.42, corresponding to p = 0.08 and p = 0.92.
+    const Real moroBoundaryProbabilities[] = { 0.08, 0.080001,
+                                                0.919999, 0.92 };
+    for (Real probability : moroBoundaryProbabilities) {
+        BOOST_CHECK(std::isfinite(moroInvCum(probability)));
+        // Acklam provides a more accurate independent reference here.
         BOOST_CHECK_CLOSE(moroInvCum(probability), invCum(probability), 1.0e-3);
     }
+
+    // The two approximations should not introduce a visible jump at the switch.
     BOOST_CHECK_SMALL(
         std::fabs((moroInvCum(0.080001) - moroInvCum(0.08)) -
                   (invCum(0.080001) - invCum(0.08))),
-        1.0e-4);
+        1.0e-4); // absolute continuity tolerance
     BOOST_CHECK_SMALL(
         std::fabs((moroInvCum(0.92) - moroInvCum(0.919999)) -
                   (invCum(0.92) - invCum(0.919999))),
-        1.0e-4);
+        1.0e-4); // absolute continuity tolerance
     BOOST_CHECK_THROW(MoroInverseCumulativeNormal(0.0, -1.0), Error);
     BOOST_CHECK_THROW(MoroInverseCumulativeNormal(
                           0.0, std::numeric_limits<Real>::quiet_NaN()), Error);
@@ -392,6 +397,7 @@ BOOST_AUTO_TEST_CASE(testMaddockNormalDistributions) {
 
     MaddockInverseCumulativeNormal maddockInvCum;
     MaddockCumulativeNormal maddockCum;
+    // Use Boost.Math independently to check the Boost-backed wrappers.
     const boost::math::normal_distribution<Real> standardNormal;
     const Real probabilities[] = { 1.0e-10, 1.0e-6, 0.01, 0.1, 0.5, 0.9,
                                    0.99, 1.0 - 1.0e-6, 1.0 - 1.0e-10 };
@@ -402,6 +408,7 @@ BOOST_AUTO_TEST_CASE(testMaddockNormalDistributions) {
         BOOST_CHECK_CLOSE(maddockCum(maddockInvCum(probability)), probability,
                           1.0e-10);
     }
+    // Boost.Math throws at exact inverse-CDF endpoints.
     BOOST_CHECK_THROW(maddockInvCum(0.0), std::exception);
     BOOST_CHECK_THROW(maddockInvCum(1.0), std::exception);
     BOOST_CHECK_CLOSE(maddockCum(0.0), 0.5, 1.0e-12);
@@ -427,6 +434,8 @@ BOOST_AUTO_TEST_CASE(testCumulativeNormal) {
     const boost::math::normal_distribution<Real> standardNormal;
     Real previous = 0.0;
     for (Real x : { -6.0, -10.0, -20.0 }) {
+        // The asymptotic implementation is less accurate than Boost here,
+        // but remains within this relative tolerance in the lower tail.
         BOOST_CHECK_CLOSE(cumulative(x), boost::math::cdf(standardNormal, x),
                           1.0e-5);
     }

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -330,6 +330,12 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativeNormal) {
                       1.0e-6);
     BOOST_CHECK_CLOSE(invCum(0.1), -invCum(0.9), 1.0e-12);
 
+    // Values sufficiently close to the endpoints are recovered as finite
+    // sentinels; values outside that recovery tolerance are rejected.
+    BOOST_CHECK_EQUAL(invCum(-0.5 * QL_EPSILON), QL_MIN_REAL);
+    BOOST_CHECK_THROW(invCum(-2.0 * QL_EPSILON), Error);
+    BOOST_CHECK_THROW(invCum(1.0 + 100.0 * QL_EPSILON), Error);
+
     const Real probabilities[] = { 1.0e-6, 0.01, 0.1, 0.5, 0.9, 0.99,
                                    1.0 - 1.0e-6 };
     Real previous = -QL_MAX_REAL;
@@ -360,6 +366,7 @@ BOOST_AUTO_TEST_CASE(testMoroInverseCumulativeNormal) {
 
     InverseCumulativeNormal invCum;
     MoroInverseCumulativeNormal moroInvCum;
+    const boost::math::normal_distribution<Real> standardNormal;
     BOOST_CHECK(std::isfinite(moroInvCum(QL_EPSILON)));
     BOOST_CHECK(std::isfinite(moroInvCum(1.0 - QL_EPSILON)));
     BOOST_CHECK_THROW(moroInvCum(0.0), Error);
@@ -375,6 +382,10 @@ BOOST_AUTO_TEST_CASE(testMoroInverseCumulativeNormal) {
         BOOST_CHECK(std::isfinite(moroInvCum(probability)));
         // Acklam provides a more accurate independent reference here.
         BOOST_CHECK_CLOSE(moroInvCum(probability), invCum(probability), 1.0e-3);
+        // Boost.Math provides a second independent reference for the tails.
+        BOOST_CHECK_CLOSE(moroInvCum(probability),
+                          boost::math::quantile(standardNormal, probability),
+                          1.0e-3);
     }
 
     // The two approximations should not introduce a visible jump at the switch.
@@ -402,11 +413,27 @@ BOOST_AUTO_TEST_CASE(testMaddockNormalDistributions) {
     const Real probabilities[] = { 1.0e-10, 1.0e-6, 0.01, 0.1, 0.5, 0.9,
                                    0.99, 1.0 - 1.0e-6, 1.0 - 1.0e-10 };
     for (Real probability : probabilities) {
+        // Check inverse-CDF accuracy against Boost and the CDF/inverse round trip.
         BOOST_CHECK_CLOSE(maddockInvCum(probability),
                           boost::math::quantile(standardNormal, probability),
                           1.0e-10);
         BOOST_CHECK_CLOSE(maddockCum(maddockInvCum(probability)), probability,
                           1.0e-10);
+    }
+    // Verify the location-scale transformation against an independent Boost
+    // distribution, in addition to the standard-normal round-trip checks.
+    MaddockInverseCumulativeNormal shiftedMaddockInvCum(3.0, 2.0);
+    MaddockCumulativeNormal shiftedMaddockCum(3.0, 2.0);
+    const boost::math::normal_distribution<Real> shiftedStandardNormal(3.0, 2.0);
+    for (Real probability : probabilities) {
+        // Check the inverse location-scale transformation against Boost.
+        BOOST_CHECK_CLOSE(shiftedMaddockInvCum(probability),
+                          boost::math::quantile(shiftedStandardNormal, probability),
+                          1.0e-10);
+        // Check the corresponding transformed CDF round trip.
+        BOOST_CHECK_CLOSE(shiftedMaddockCum(3.0 + 2.0 *
+                                            maddockInvCum(probability)),
+                          probability, 1.0e-10);
     }
     // Boost.Math throws at exact inverse-CDF endpoints.
     BOOST_CHECK_THROW(maddockInvCum(0.0), std::exception);
@@ -433,6 +460,12 @@ BOOST_AUTO_TEST_CASE(testCumulativeNormal) {
     BOOST_CHECK_EQUAL(cumulative(infinity), 1.0);
     const boost::math::normal_distribution<Real> standardNormal;
     Real previous = 0.0;
+    // Probe both sides of the direct/asymptotic CDF switch at probability 1e-8.
+    const Real cdfSwitch = boost::math::quantile(standardNormal, 1.0e-8);
+    for (Real x : { cdfSwitch - 1.0e-6, cdfSwitch, cdfSwitch + 1.0e-6 }) {
+        BOOST_CHECK_SMALL(cumulative(x) - boost::math::cdf(standardNormal, x),
+                          1.0e-14);
+    }
     for (Real x : { -6.0, -10.0, -20.0 }) {
         // The asymptotic implementation is less accurate than Boost here,
         // but remains within this relative tolerance in the lower tail.
@@ -445,6 +478,21 @@ BOOST_AUTO_TEST_CASE(testCumulativeNormal) {
         BOOST_CHECK(value >= 0.0);
         BOOST_CHECK(value <= 1.0);
         previous = value;
+    }
+    for (Real x : { 6.0, 10.0, 20.0 }) {
+        BOOST_CHECK_SMALL(cumulative(x) - boost::math::cdf(standardNormal, x),
+                          1.0e-14);
+    }
+
+    NormalDistribution shiftedNormal(3.0, 2.0);
+    CumulativeNormalDistribution shiftedCumulative(3.0, 2.0);
+    NormalDistribution standardDensity;
+    for (Real x : { 1.0, 3.0, 5.0 }) {
+        const Real standardValue = (x - 3.0) / 2.0;
+        BOOST_CHECK_CLOSE(shiftedNormal(x), standardDensity(standardValue) / 2.0,
+                          1.0e-12);
+        BOOST_CHECK_CLOSE(shiftedCumulative(x), cumulative(standardValue),
+                          1.0e-12);
     }
 
     BOOST_CHECK_THROW(NormalDistribution(0.0, 0.0), Error);

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -25,6 +25,7 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <algorithm>
+#include <limits>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/distributions/bivariatenormaldistribution.hpp>
 #include <ql/math/distributions/bivariatestudenttdistribution.hpp>
@@ -309,6 +310,58 @@ BOOST_AUTO_TEST_CASE(testNormal) {
                     << std::scientific << e << "\n"
                     << "tolerance exceeded");
     }
+}
+
+BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
+
+    BOOST_TEST_MESSAGE("Testing normal-distribution tails and invalid inputs...");
+
+    InverseCumulativeNormal invCum;
+    BOOST_CHECK(std::isfinite(invCum(0.0)));
+    BOOST_CHECK(std::isfinite(invCum(1.0)));
+    BOOST_CHECK(std::isfinite(invCum(QL_EPSILON)));
+    BOOST_CHECK(std::isfinite(invCum(1.0 - QL_EPSILON)));
+    BOOST_CHECK(invCum(0.0) < 0.0);
+    BOOST_CHECK(invCum(1.0) > 0.0);
+    BOOST_CHECK_CLOSE(invCum(0.02425), -1.972961049,
+                      1.0e-6);
+    BOOST_CHECK_CLOSE(invCum(0.97575), 1.972961049,
+                      1.0e-6);
+    BOOST_CHECK_CLOSE(invCum(0.1), -invCum(0.9), 1.0e-12);
+    BOOST_CHECK_THROW(invCum(-1.0e-8), Error);
+    BOOST_CHECK_THROW(invCum(1.0 + 1.0e-4), Error);
+
+    MoroInverseCumulativeNormal moroInvCum;
+    BOOST_CHECK(std::isfinite(moroInvCum(QL_EPSILON)));
+    BOOST_CHECK(std::isfinite(moroInvCum(1.0 - QL_EPSILON)));
+    BOOST_CHECK_THROW(moroInvCum(0.0), Error);
+    BOOST_CHECK_THROW(moroInvCum(1.0), Error);
+    BOOST_CHECK_THROW(moroInvCum(-1.0e-8), Error);
+    BOOST_CHECK_THROW(moroInvCum(1.0 + 1.0e-8), Error);
+
+    MaddockInverseCumulativeNormal maddockInvCum;
+    BOOST_CHECK(std::isfinite(maddockInvCum(0.5)));
+    BOOST_CHECK(std::isfinite(maddockInvCum(QL_EPSILON)));
+    BOOST_CHECK(std::isfinite(maddockInvCum(1.0 - QL_EPSILON)));
+
+    MaddockCumulativeNormal maddockCum;
+    BOOST_CHECK_CLOSE(maddockCum(0.0), 0.5, 1.0e-12);
+    BOOST_CHECK(maddockCum(-1.0) < 0.5);
+    BOOST_CHECK(maddockCum(1.0) > 0.5);
+
+    BOOST_CHECK_THROW(NormalDistribution(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(CumulativeNormalDistribution(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(InverseCumulativeNormal(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(MoroInverseCumulativeNormal(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(MaddockInverseCumulativeNormal(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(MaddockCumulativeNormal(0.0, 0.0), Error);
+
+    NormalDistribution normal;
+    BOOST_CHECK_EQUAL(normal.derivative(QL_MAX_REAL), 0.0);
+    BOOST_CHECK_EQUAL(normal.derivative(-QL_MAX_REAL), 0.0);
+    const Real infinity = std::numeric_limits<Real>::infinity();
+    BOOST_CHECK_EQUAL(normal.derivative(infinity), 0.0);
+    BOOST_CHECK_EQUAL(normal.derivative(-infinity), 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(testBivariate) {

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -34,6 +34,7 @@
 #include <ql/math/distributions/poissondistribution.hpp>
 #include <ql/math/randomnumbers/stochasticcollocationinvcdf.hpp>
 #include <ql/math/comparison.hpp>
+#include <boost/math/distributions/normal.hpp>
 #include <boost/math/distributions/non_central_chi_squared.hpp>
 
 using namespace QuantLib;
@@ -316,6 +317,7 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
 
     BOOST_TEST_MESSAGE("Testing normal-distribution tails and invalid inputs...");
 
+    const Real infinity = std::numeric_limits<Real>::infinity();
     InverseCumulativeNormal invCum;
     BOOST_CHECK(std::isfinite(invCum(0.0)));
     BOOST_CHECK(std::isfinite(invCum(1.0)));
@@ -328,6 +330,23 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
     BOOST_CHECK_CLOSE(invCum(0.97575), 1.972961049,
                       1.0e-6);
     BOOST_CHECK_CLOSE(invCum(0.1), -invCum(0.9), 1.0e-12);
+
+    const Real probabilities[] = { 1.0e-6, 0.01, 0.1, 0.5, 0.9, 0.99,
+                                   1.0 - 1.0e-6 };
+    Real previous = -QL_MAX_REAL;
+    for (Real probability : probabilities) {
+        const Real value = invCum(probability);
+        BOOST_CHECK(value > previous);
+        previous = value;
+    }
+
+    InverseCumulativeNormal shiftedInvCum(3.0, 2.0);
+    for (Real probability : probabilities) {
+        BOOST_CHECK_CLOSE(shiftedInvCum(probability),
+                          3.0 + 2.0 * invCum(probability),
+                          1.0e-12);
+    }
+
     BOOST_CHECK_THROW(invCum(-1.0e-8), Error);
     BOOST_CHECK_THROW(invCum(1.0 + 1.0e-4), Error);
 
@@ -338,6 +357,10 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
     BOOST_CHECK_THROW(moroInvCum(1.0), Error);
     BOOST_CHECK_THROW(moroInvCum(-1.0e-8), Error);
     BOOST_CHECK_THROW(moroInvCum(1.0 + 1.0e-8), Error);
+    BOOST_CHECK(std::isfinite(moroInvCum(0.08)));
+    BOOST_CHECK(std::isfinite(moroInvCum(0.080001)));
+    BOOST_CHECK(std::isfinite(moroInvCum(0.919999)));
+    BOOST_CHECK(std::isfinite(moroInvCum(0.92)));
 
     MaddockInverseCumulativeNormal maddockInvCum;
     BOOST_CHECK(std::isfinite(maddockInvCum(0.5)));
@@ -349,6 +372,15 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
     BOOST_CHECK(maddockCum(-1.0) < 0.5);
     BOOST_CHECK(maddockCum(1.0) > 0.5);
 
+    CumulativeNormalDistribution cumulative;
+    BOOST_CHECK_EQUAL(cumulative(-infinity), 0.0);
+    BOOST_CHECK_EQUAL(cumulative(infinity), 1.0);
+    const boost::math::normal_distribution<Real> standardNormal;
+    for (Real x : { -6.0, -10.0, -20.0 }) {
+        BOOST_CHECK_CLOSE(cumulative(x), boost::math::cdf(standardNormal, x),
+                          1.0e-5);
+    }
+
     BOOST_CHECK_THROW(NormalDistribution(0.0, 0.0), Error);
     BOOST_CHECK_THROW(CumulativeNormalDistribution(0.0, 0.0), Error);
     BOOST_CHECK_THROW(InverseCumulativeNormal(0.0, 0.0), Error);
@@ -359,7 +391,6 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
     NormalDistribution normal;
     BOOST_CHECK_EQUAL(normal.derivative(QL_MAX_REAL), 0.0);
     BOOST_CHECK_EQUAL(normal.derivative(-QL_MAX_REAL), 0.0);
-    const Real infinity = std::numeric_limits<Real>::infinity();
     BOOST_CHECK_EQUAL(normal.derivative(infinity), 0.0);
     BOOST_CHECK_EQUAL(normal.derivative(-infinity), 0.0);
 }

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -313,11 +313,10 @@ BOOST_AUTO_TEST_CASE(testNormal) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
+BOOST_AUTO_TEST_CASE(testInverseCumulativeNormal) {
 
-    BOOST_TEST_MESSAGE("Testing normal-distribution tails and invalid inputs...");
+    BOOST_TEST_MESSAGE("Testing inverse cumulative normal distribution...");
 
-    const Real infinity = std::numeric_limits<Real>::infinity();
     InverseCumulativeNormal invCum;
     BOOST_CHECK(std::isfinite(invCum(0.0)));
     BOOST_CHECK(std::isfinite(invCum(1.0)));
@@ -349,7 +348,17 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
 
     BOOST_CHECK_THROW(invCum(-1.0e-8), Error);
     BOOST_CHECK_THROW(invCum(1.0 + 1.0e-4), Error);
+    BOOST_CHECK_THROW(InverseCumulativeNormal(0.0, -1.0), Error);
+    BOOST_CHECK_THROW(InverseCumulativeNormal(0.0,
+                                              std::numeric_limits<Real>::quiet_NaN()),
+                      Error);
+}
 
+BOOST_AUTO_TEST_CASE(testMoroInverseCumulativeNormal) {
+
+    BOOST_TEST_MESSAGE("Testing Moro inverse cumulative normal distribution...");
+
+    InverseCumulativeNormal invCum;
     MoroInverseCumulativeNormal moroInvCum;
     BOOST_CHECK(std::isfinite(moroInvCum(QL_EPSILON)));
     BOOST_CHECK(std::isfinite(moroInvCum(1.0 - QL_EPSILON)));
@@ -372,32 +381,67 @@ BOOST_AUTO_TEST_CASE(testNormalTailAndErrorCases) {
         std::fabs((moroInvCum(0.92) - moroInvCum(0.919999)) -
                   (invCum(0.92) - invCum(0.919999))),
         1.0e-4);
+    BOOST_CHECK_THROW(MoroInverseCumulativeNormal(0.0, -1.0), Error);
+    BOOST_CHECK_THROW(MoroInverseCumulativeNormal(
+                          0.0, std::numeric_limits<Real>::quiet_NaN()), Error);
+}
+
+BOOST_AUTO_TEST_CASE(testMaddockNormalDistributions) {
+
+    BOOST_TEST_MESSAGE("Testing Maddock normal distributions...");
 
     MaddockInverseCumulativeNormal maddockInvCum;
-    BOOST_CHECK(std::isfinite(maddockInvCum(0.5)));
-    BOOST_CHECK(std::isfinite(maddockInvCum(QL_EPSILON)));
-    BOOST_CHECK(std::isfinite(maddockInvCum(1.0 - QL_EPSILON)));
-
     MaddockCumulativeNormal maddockCum;
+    const boost::math::normal_distribution<Real> standardNormal;
+    const Real probabilities[] = { 1.0e-10, 1.0e-6, 0.01, 0.1, 0.5, 0.9,
+                                   0.99, 1.0 - 1.0e-6, 1.0 - 1.0e-10 };
+    for (Real probability : probabilities) {
+        BOOST_CHECK_CLOSE(maddockInvCum(probability),
+                          boost::math::quantile(standardNormal, probability),
+                          1.0e-10);
+        BOOST_CHECK_CLOSE(maddockCum(maddockInvCum(probability)), probability,
+                          1.0e-10);
+    }
+    BOOST_CHECK_THROW(maddockInvCum(0.0), std::exception);
+    BOOST_CHECK_THROW(maddockInvCum(1.0), std::exception);
     BOOST_CHECK_CLOSE(maddockCum(0.0), 0.5, 1.0e-12);
     BOOST_CHECK(maddockCum(-1.0) < 0.5);
     BOOST_CHECK(maddockCum(1.0) > 0.5);
+    BOOST_CHECK_THROW(MaddockInverseCumulativeNormal(0.0, -1.0), Error);
+    BOOST_CHECK_THROW(MaddockCumulativeNormal(0.0, -1.0), Error);
+    BOOST_CHECK_THROW(MaddockInverseCumulativeNormal(
+                          0.0, std::numeric_limits<Real>::quiet_NaN()), Error);
+    BOOST_CHECK_THROW(MaddockCumulativeNormal(
+                          0.0, std::numeric_limits<Real>::quiet_NaN()), Error);
+}
+
+BOOST_AUTO_TEST_CASE(testCumulativeNormal) {
+
+    BOOST_TEST_MESSAGE("Testing cumulative normal distribution tails...");
+
+    const Real infinity = std::numeric_limits<Real>::infinity();
 
     CumulativeNormalDistribution cumulative;
     BOOST_CHECK_EQUAL(cumulative(-infinity), 0.0);
     BOOST_CHECK_EQUAL(cumulative(infinity), 1.0);
     const boost::math::normal_distribution<Real> standardNormal;
+    Real previous = 0.0;
     for (Real x : { -6.0, -10.0, -20.0 }) {
         BOOST_CHECK_CLOSE(cumulative(x), boost::math::cdf(standardNormal, x),
                           1.0e-5);
     }
+    for (Real x : { -20.0, -10.0, -6.0, -1.0, 0.0, 1.0, 6.0, 10.0, 20.0 }) {
+        const Real value = cumulative(x);
+        BOOST_CHECK(value >= previous);
+        BOOST_CHECK(value >= 0.0);
+        BOOST_CHECK(value <= 1.0);
+        previous = value;
+    }
 
     BOOST_CHECK_THROW(NormalDistribution(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(NormalDistribution(0.0, -1.0), Error);
     BOOST_CHECK_THROW(CumulativeNormalDistribution(0.0, 0.0), Error);
-    BOOST_CHECK_THROW(InverseCumulativeNormal(0.0, 0.0), Error);
-    BOOST_CHECK_THROW(MoroInverseCumulativeNormal(0.0, 0.0), Error);
-    BOOST_CHECK_THROW(MaddockInverseCumulativeNormal(0.0, 0.0), Error);
-    BOOST_CHECK_THROW(MaddockCumulativeNormal(0.0, 0.0), Error);
+    BOOST_CHECK_THROW(CumulativeNormalDistribution(0.0, -1.0), Error);
 
     NormalDistribution normal;
     BOOST_CHECK_EQUAL(normal.derivative(QL_MAX_REAL), 0.0);


### PR DESCRIPTION
-Added more test cases, especially in tails, around branches and regression against other implementations.
-Improved documentation.
-Aligned handling of check that sigma is positive across all implementations (for Maddock, check was delegated to Boost).

Potentially breaking changes:
-Fix of tail behaviour of NormalDistribution::derivative: In the tail the derivative should converges zero, but previously returned NaN.