### PR TITLE
Fix hybrid annealing temperature termination

### DIFF
--- a/ql/experimental/math/hybridsimulatedannealing.hpp
+++ b/ql/experimental/math/hybridsimulatedannealing.hpp
@@ -31,6 +31,7 @@ Mathl. Comput. Modelling, 967-973, 1989
 #include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/math/optimization/problem.hpp>
 #include <ql/shared_ptr.hpp>
+#include <algorithm>
 #include <utility>
 
 namespace QuantLib {
@@ -209,8 +210,9 @@ namespace QuantLib {
             temperature_(currentTemperature, currentTemperature, annealStep);
 
             //Check if temperature condition is breached
-            for (Size i = 0; i < n; i++)
-                temperatureBreached = temperatureBreached && currentTemperature[i] < endTemperature_;
+            temperatureBreached = std::all_of(
+                currentTemperature.begin(), currentTemperature.end(),
+                [this](Real temperature) { return temperature < endTemperature_; });
         }
         
         //Change end criteria type if appropriate

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -94,15 +94,31 @@ struct StationarySampler {
     }
 };
 
+struct ImprovingSampler {
+    void operator()(Array& newPoint, const Array& currentPoint, const Array&) const {
+        newPoint = currentPoint / 2.0;
+    }
+};
+
 struct RejectAllMoves {
     bool operator()(Real, Real, const Array&) const { return false; }
+};
+
+struct AcceptAllMoves {
+    bool operator()(Real, Real, const Array&) const { return true; }
 };
 
 struct StagedCooling {
     void operator()(Array& newTemperature, const Array&, const Array& steps) const {
         std::fill(newTemperature.begin(), newTemperature.end(), 0.0);
         if (steps[0] <= 2.0)
-            newTemperature[1] = 1.0;
+            newTemperature[1] = 0.5;
+    }
+};
+
+struct ConstantTemperature {
+    void operator()(Array& newTemperature, const Array& currentTemperature, const Array&) const {
+        newTemperature = currentTemperature;
     }
 };
 
@@ -112,6 +128,25 @@ class MultidimensionalQuadratic : public CostFunction {
 
     Array values(const Array& x) const override { return Array(1, value(x)); }
 };
+
+template <class Sampler, class Probability, class Temperature>
+std::pair<EndCriteria::Type, Size> runHybridAnnealing(const Sampler& sampler,
+                                                      const Probability& probability,
+                                                      Temperature temperature,
+                                                      Size maxIterations,
+                                                      Size maxStationaryStateIterations) {
+    MultidimensionalQuadratic costFunction;
+    NoConstraint constraint;
+    Problem problem(costFunction, constraint, Array(2, 1.0));
+    EndCriteria endCriteria(maxIterations, maxStationaryStateIterations, 1e-8, 1e-8, 1e-8);
+
+    using Annealing = HybridSimulatedAnnealing<Sampler, Probability, Temperature>;
+    Annealing annealing(sampler, probability, std::move(temperature), ReannealingTrivial(), 1.0,
+                        0.5, 0, Annealing::NoResetScheme, 0, nullptr, Annealing::NoLocalOptimize);
+
+    const EndCriteria::Type result = annealing.minimize(problem, endCriteria);
+    return std::make_pair(result, problem.functionEvaluation());
+}
 
 
 // The goal of this cost function is simply to call another optimization inside
@@ -397,21 +432,31 @@ BOOST_AUTO_TEST_CASE(nestedOptimizationTest) {
 BOOST_AUTO_TEST_CASE(testHybridSimulatedAnnealingTemperatureTermination) {
     BOOST_TEST_MESSAGE("Testing hybrid simulated annealing temperature termination...");
 
-    MultidimensionalQuadratic costFunction;
-    NoConstraint constraint;
-    Problem problem(costFunction, constraint, Array(2, 1.0));
-    EndCriteria endCriteria(100, 50, 1e-8, 1e-8, 1e-8);
+    const auto result =
+        runHybridAnnealing(StationarySampler(), RejectAllMoves(), StagedCooling(), 100, 50);
 
-    using Annealing = HybridSimulatedAnnealing<StationarySampler, RejectAllMoves,
-                                                StagedCooling>;
-    Annealing annealing(StationarySampler(), RejectAllMoves(), StagedCooling(),
-                        ReannealingTrivial(), 1.0, 0.5, 0,
-                        Annealing::NoResetScheme, 0, nullptr,
-                        Annealing::NoLocalOptimize);
+    BOOST_CHECK_EQUAL(result.first, EndCriteria::None);
+    BOOST_CHECK_EQUAL(result.second, 3);
+}
 
-    annealing.minimize(problem, endCriteria);
+BOOST_AUTO_TEST_CASE(testHybridSimulatedAnnealingIterationTermination) {
+    BOOST_TEST_MESSAGE("Testing hybrid simulated annealing iteration termination...");
 
-    BOOST_CHECK_EQUAL(problem.functionEvaluation(), 3);
+    const auto result =
+        runHybridAnnealing(ImprovingSampler(), AcceptAllMoves(), ConstantTemperature(), 3, 2);
+
+    BOOST_CHECK_EQUAL(result.first, EndCriteria::MaxIterations);
+    BOOST_CHECK_EQUAL(result.second, 4);
+}
+
+BOOST_AUTO_TEST_CASE(testHybridSimulatedAnnealingStationaryTermination) {
+    BOOST_TEST_MESSAGE("Testing hybrid simulated annealing stationary-point termination...");
+
+    const auto result =
+        runHybridAnnealing(StationarySampler(), RejectAllMoves(), ConstantTemperature(), 100, 2);
+
+    BOOST_CHECK_EQUAL(result.first, EndCriteria::StationaryPoint);
+    BOOST_CHECK_EQUAL(result.second, 3);
 }
 
 

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -24,6 +24,7 @@
 #include "preconditions.hpp"
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include <ql/experimental/math/hybridsimulatedannealing.hpp>
 #include <ql/math/optimization/bfgs.hpp>
 #include <ql/math/optimization/conjugategradient.hpp>
 #include <ql/math/optimization/constraint.hpp>
@@ -85,6 +86,31 @@ class OneDimensionalPolynomialDegreeN : public CostFunction {
   private:
     const Array coefficients_;
     const Size polynomialDegree_;
+};
+
+struct StationarySampler {
+    void operator()(Array& newPoint, const Array& currentPoint, const Array&) const {
+        newPoint = currentPoint;
+    }
+};
+
+struct RejectAllMoves {
+    bool operator()(Real, Real, const Array&) const { return false; }
+};
+
+struct StagedCooling {
+    void operator()(Array& newTemperature, const Array&, const Array& steps) const {
+        std::fill(newTemperature.begin(), newTemperature.end(), 0.0);
+        if (steps[0] <= 2.0)
+            newTemperature[1] = 1.0;
+    }
+};
+
+class MultidimensionalQuadratic : public CostFunction {
+  public:
+    Real value(const Array& x) const override { return DotProduct(x, x); }
+
+    Array values(const Array& x) const override { return Array(1, value(x)); }
 };
 
 
@@ -366,6 +392,26 @@ BOOST_AUTO_TEST_CASE(nestedOptimizationTest) {
     EndCriteria endCriteria(1000, 100, 1e-5, 1e-5, 1e-5);
     optimizationMethod.minimize(problem, endCriteria);
 
+}
+
+BOOST_AUTO_TEST_CASE(testHybridSimulatedAnnealingTemperatureTermination) {
+    BOOST_TEST_MESSAGE("Testing hybrid simulated annealing temperature termination...");
+
+    MultidimensionalQuadratic costFunction;
+    NoConstraint constraint;
+    Problem problem(costFunction, constraint, Array(2, 1.0));
+    EndCriteria endCriteria(100, 50, 1e-8, 1e-8, 1e-8);
+
+    using Annealing = HybridSimulatedAnnealing<StationarySampler, RejectAllMoves,
+                                                StagedCooling>;
+    Annealing annealing(StationarySampler(), RejectAllMoves(), StagedCooling(),
+                        ReannealingTrivial(), 1.0, 0.5, 0,
+                        Annealing::NoResetScheme, 0, nullptr,
+                        Annealing::NoLocalOptimize);
+
+    annealing.minimize(problem, endCriteria);
+
+    BOOST_CHECK_EQUAL(problem.functionEvaluation(), 3);
 }
 
 


### PR DESCRIPTION
**Summary**

Fixes the ending-temperature condition in hybrid simulated annealing.

Code maintains a separate temperature for each optimisation dimension. These temperatures control the scale of candidate moves independently, as described by the adaptive simulated annealing approach used by this implementation:

- Lester Ingber, [“Very Fast Simulated Re-Annealing”](https://doi.org/10.1016/0895-7177(89)90202-1), 1989.

Termination should therefore occur only when every dimension has cooled below `endTemperature_`. Stopping when only one dimension is below the threshold could terminate the search while other dimensions are still exploring at higher temperatures. Formally, the condition is:

$$
\forall i,\quad T_i < T_{\mathrm{end}}
$$

The previous implementation attempted to combine these comparisons using logical AND:

```cpp
temperatureBreached =
    temperatureBreached && currentTemperature[i] < endTemperature_;
```

However, `temperatureBreached` was initialized to `false`. Since `false && x` is always `false`, the flag could never become true and `endTemperature_` was effectively ignored.

The fix uses `std::all_of` to express the intended condition directly.

A deterministic multidimensional regression test confirms that optimisation continues while any dimension remains above the threshold and stops after all dimensions cross it.

**Testing**
Added tests.

**Compatibility**

This intentionally changes runtime behavior by restoring the configured temperature-based stopping condition. It introduces no API or ABI changes and does not increase the asymptotic cost of the check.